### PR TITLE
Added refunds to invoice details screen

### DIFF
--- a/app/controllers/kaui/invoices_controller.rb
+++ b/app/controllers/kaui/invoices_controller.rb
@@ -17,6 +17,9 @@ class Kaui::InvoicesController < Kaui::EngineController
           @payments.each do |payment|
             # The payment method may have been deleted
             @payment_methods[payment.payment_id] = Kaui::KillbillHelper::get_payment_method(payment.payment_method_id) rescue nil
+
+            #get the refunds for the payment
+            payment.refunds = Kaui::KillbillHelper::get_refunds_for_payment(payment.payment_id) rescue []
           end
 
           @subscriptions = {}

--- a/app/views/kaui/invoices/show.html.erb
+++ b/app/views/kaui/invoices/show.html.erb
@@ -82,6 +82,13 @@
       <%= render :partial => "kaui/payments/payments_table" %>
     <% end %>
   </div>
+
+  <div class="page-header">
+    <% if @payments.present? %>
+      <%= render :partial => "kaui/refunds/refunds_table" %>
+    <% end %>
+  </div>
+
 <% else %>
   <p>Invoice not found</p>
 <% end %>

--- a/app/views/kaui/refunds/_refunds_table.html.erb
+++ b/app/views/kaui/refunds/_refunds_table.html.erb
@@ -1,0 +1,31 @@
+<div class="page-header">
+  <h3>Refunds</h3>
+</div>
+<table class="table table-condensed table-striped data-table">
+  <thead>
+    <tr>
+      <th>Requested date</th>
+      <th>Effective date</th>
+      <th>Amount Refunded</th>
+      <th>Adjusted</th>
+      <th>Refund ID</th>
+      <th>Payment ID</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if @payments.present? %>
+      <% @payments.each do |payment| %>
+        <% payment.refunds.each do |refund| %>
+        <tr>
+          <td><%= format_date(refund.requested_date, @account.timezone).html_safe if refund.requested_date.present? %></td>
+          <td><%= format_date(refund.effective_date, @account.timezone).html_safe if refund.effective_date.present? %></td>
+          <td><%= humanized_money_with_symbol refund.amount_to_money %> (<%= refund.currency %>)</td>
+          <td><%= refund.adjusted %></td>
+          <td><%= link_to refund.refund_id, refund_path(refund.refund_id) %></td>
+          <td><%= refund.payment_id %></td>
+        </tr>
+        <% end #end refunds%>
+      <% end #end payments%>
+    <% end #end if payments present%>
+  </tbody>
+</table>


### PR DESCRIPTION
Added refunds to invoice details screen for ease of end - user to view in the same screen instead of going to the billing timeline
![refunds_added](https://f.cloud.github.com/assets/582200/728765/794c16de-e21a-11e2-99e9-e07cba04e1d9.png)
