### PR TITLE
Wrong plugin name submitted when uploading a plugin config #165

### DIFF
--- a/app/assets/javascripts/kaui/kaui.js
+++ b/app/assets/javascripts/kaui/kaui.js
@@ -233,3 +233,27 @@ function ajaxCloseAlert(messageBox) {
     messageBox.find("#ajaxErrorMessage").text('');
     messageBox.hide();
 }
+
+// global helper function to validate if a variable is null or empty or undefined
+function isNullOrUndefined(value) {
+    if (value == undefined || value == null) {
+        return true;
+    }
+    return false;
+}
+
+function isBlank(value) {
+    if (isNullOrUndefined(value)) {
+        return true;
+    }
+
+    if (jQuery.type(value) === "string" && value.trim().length == 0) {
+        return true;
+    } else if (jQuery.type(value) === "array" && value.length == 0) {
+        return true;
+    } else if (jQuery.type(value) === "object" && jQuery.isEmptyObject(value)) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/app/assets/stylesheets/kaui/common.less
+++ b/app/assets/stylesheets/kaui/common.less
@@ -616,7 +616,11 @@ input:checked + .slider:before {
   display: none;
 }
 
-.autocomplete-allowed-user {
+.autocomplete-allowed-user, .autocomplete-override {
     list-style: none;
     padding-left: 10px;
+}
+
+.plugin-suggestion{
+  white-space: nowrap;
 }

--- a/app/assets/stylesheets/kaui/common.less
+++ b/app/assets/stylesheets/kaui/common.less
@@ -626,5 +626,10 @@ input:checked + .slider:before {
 }
 
 .toggle-container{
+  padding-right: 0;
+  width: 55px;
+}
+
+.toggle-label {
   text-align: left !important;
 }

--- a/app/assets/stylesheets/kaui/common.less
+++ b/app/assets/stylesheets/kaui/common.less
@@ -624,3 +624,7 @@ input:checked + .slider:before {
 .plugin-suggestion{
   white-space: nowrap;
 }
+
+.toggle-container{
+  text-align: left !important;
+}

--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -82,6 +82,9 @@ class Kaui::AdminTenantsController < Kaui::EngineController
     fetch_overdue_xml = promise { Kaui::Overdue::get_tenant_overdue_config('xml', options) rescue @overdue_xml = nil }
 
     plugin_repository = Kaui::AdminTenant::get_plugin_repository
+    # hack:: replace paypal key with paypal_express, to set configuration and allow the ui to find the right configuration inputs
+    plugin_repository = plugin_repository.inject({}) { |p, (k,v)| p[k.to_s.sub(/\Apaypal/, 'paypal_express').to_sym] = v; p }
+
 
     fetch_plugin_config = promise { Kaui::AdminTenant::get_oss_plugin_info(plugin_repository) }
     fetch_tenant_plugin_config = promise { Kaui::AdminTenant::get_tenant_plugin_config(plugin_repository, options) }
@@ -309,11 +312,11 @@ class Kaui::AdminTenantsController < Kaui::EngineController
     plugin_name = params[:plugin_name]
     plugin_properties = params[:plugin_properties]
     plugin_type = params[:plugin_type]
+    plugin_key = params[:plugin_key]
 
-    plugin_config = Kaui::AdminTenant.format_plugin_config(plugin_name.gsub('killbill-',''), plugin_type, plugin_properties)
+    plugin_config = Kaui::AdminTenant.format_plugin_config(plugin_key, plugin_type, plugin_properties)
 
-    key = plugin_type.present? && !plugin_name.include?('killbill-') ? "killbill-#{plugin_name}" : plugin_name
-    Kaui::AdminTenant.upload_tenant_plugin_config(key, plugin_config, options[:username], nil, comment, options)
+    Kaui::AdminTenant.upload_tenant_plugin_config(plugin_name, plugin_config, options[:username], nil, comment, options)
 
     redirect_to admin_tenant_path(current_tenant.id), :notice => 'Config for plugin was successfully uploaded'
   end
@@ -415,23 +418,23 @@ class Kaui::AdminTenantsController < Kaui::EngineController
     end
   end
 
-  def validate_plugin_name
+  def suggest_plugin_name
     json_response do
       message = nil
       entered_plugin_name = params.require(:plugin_name)
-      nodes_info = KillBillClient::Model::NodesInfo.nodes_info(options_for_klient) || []
-      plugins_info = nodes_info.first.plugins_info || []
+      plugin_repository = view_context.plugin_repository
 
-      found_plugin, weights = fuzzy_match(entered_plugin_name, plugins_info)
+      found_plugin, weights = fuzzy_match(entered_plugin_name, plugin_repository)
 
       if weights.size > 0
         plugin_anchor = view_context.link_to(weights[0][:plugin_name], '#', id: 'suggested',
                                             data: {
                                                 plugin_name: weights[0][:plugin_name],
                                                 plugin_key: weights[0][:plugin_key],
+                                                plugin_type: weights[0][:plugin_type],
                                             })
-        message = "Similar plugin already installed: '#{plugin_anchor}'" if weights[0][:worth_weight].to_f >= 1.0
-        message = "Did you mean '#{plugin_anchor}'?" if weights[0][:worth_weight].to_f < 1.0
+        message = "Similar plugin already installed: '#{plugin_anchor}'" if weights[0][:worth_weight].to_f >= 1.0 && weights[0][:installed]
+        message = "Did you mean '#{plugin_anchor}'?" if weights[0][:worth_weight].to_f < 1.0 || !weights[0][:installed]
       end
       { suggestion: message, plugin: found_plugin }
     end
@@ -472,18 +475,18 @@ class Kaui::AdminTenantsController < Kaui::EngineController
     data.split(/(?=[A-Z])|(?=[_])|(?=[-])|(?=[ ])/).select {|member| !member.gsub(/[_-]/,'').strip.empty?}.map { |member| member.gsub(/[_-]/,'').strip.downcase }
   end
 
-  def fuzzy_match(entered_plugin_name, plugins_info)
+  def fuzzy_match(entered_plugin_name, plugin_repository)
     splitted_entered_plugin_name = split_camel_dash_underscore_space(entered_plugin_name)
     worth_of_non_words = 0.5 / splitted_entered_plugin_name.size.to_i
 
     weights = []
 
-    plugins_info.each do |plugin|
-      next if plugin.version.nil?
-      return plugin, [] if plugin.plugin_name == entered_plugin_name || plugin.plugin_key == entered_plugin_name
+    plugin_repository.each do |plugin|
+      return plugin, [] if plugin[:plugin_name] == entered_plugin_name || plugin[:plugin_key] == entered_plugin_name
 
-      splitted_plugin_name = split_camel_dash_underscore_space(plugin.plugin_name)
-      weight = { :plugin_name => plugin.plugin_name, :plugin_key => plugin.plugin_key, :worth_weight => 0.0 }
+      splitted_plugin_name = split_camel_dash_underscore_space(plugin[:plugin_name])
+      weight = { :plugin_name => plugin[:plugin_name], :plugin_key => plugin[:plugin_key],
+                 :plugin_type => plugin[:plugin_type], :installed => plugin[:installed], :worth_weight => 0.0 }
       splitted_entered_plugin_name.each do |entered|
         if splitted_plugin_name.include?(entered)
           weight[:worth_weight] = weight[:worth_weight] + 1.0

--- a/app/helpers/kaui/plugin_helper.rb
+++ b/app/helpers/kaui/plugin_helper.rb
@@ -1,0 +1,59 @@
+module Kaui
+  module PluginHelper
+    # including plugin that are installed
+    def plugin_repository
+      plugins = []
+      plugin_repository = Kaui::AdminTenant::get_plugin_repository
+      installed_plugins = installed_plugins()
+
+      plugin_repository.each_pair do |key, info|
+        found_plugin = installed_plugins.reject! { |p| p.plugin_key.eql?(key.to_s) }
+        plugins << {
+            plugin_key: plugin_key(key.to_s, info),
+            plugin_name: plugin_name(key.to_s, info),
+            plugin_type: info[:type],
+            installed: !found_plugin.nil?
+        }
+      end
+
+      installed_plugins.each do |plugin|
+        plugins << {
+            plugin_key: plugin.plugin_key,
+            plugin_name: plugin.plugin_name,
+            plugin_type: nil,
+            installed: true
+        }
+      end
+
+      plugins.sort! { |a,b| a[:plugin_key] <=> b[:plugin_key] && b[:installed].to_s <=> a[:installed].to_s }
+      puts '.'*50
+      puts plugins.to_json
+      plugins
+    end
+
+    private
+
+      def plugin_name(key, info)
+        if info[:artifact_id].nil?
+          "killbill-#{key}"
+        else
+          "killbill-#{info[:artifact_id].gsub('killbill-','').gsub('-plugin','')}"
+        end
+      end
+
+      def plugin_key(key, info)
+        if info[:artifact_id].nil?
+          "#{key}"
+        else
+          "#{info[:artifact_id].gsub('killbill-','').gsub('-plugin','')}"
+        end
+      end
+
+      def installed_plugins
+        nodes_info = KillBillClient::Model::NodesInfo.nodes_info(Kaui.current_tenant_user_options(current_user, session)) || []
+        plugins_info = nodes_info.first.plugins_info || []
+
+        plugins_info.select { |plugin| !plugin.version.nil?}
+      end
+  end
+end

--- a/app/helpers/kaui/plugin_helper.rb
+++ b/app/helpers/kaui/plugin_helper.rb
@@ -26,8 +26,6 @@ module Kaui
       end
 
       plugins.sort! { |a,b| a[:plugin_key] <=> b[:plugin_key] && b[:installed].to_s <=> a[:installed].to_s }
-      puts '.'*50
-      puts plugins.to_json
       plugins
     end
 
@@ -42,10 +40,11 @@ module Kaui
       end
 
       def plugin_key(key, info)
-        if info[:artifact_id].nil?
-          "#{key}"
+        # hack:: replace paypal key with paypal_express, to set configuration and allow the ui to find the right configuration inputs
+        if key.eql?('paypal')
+          'paypal_express'
         else
-          "#{info[:artifact_id].gsub('killbill-','').gsub('-plugin','')}"
+          "#{key}"
         end
       end
 

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -63,6 +63,8 @@ class Kaui::AdminTenant < KillBillClient::Model::Tenant
 
         # Extract killbill key for oss plugins based on convention 'killbill-KEY'
         plugin_key = killbill_key.gsub(/killbill-/, '') if killbill_key.start_with?('killbill-')
+        # hack:: rewrite key, to allow the ui to find the right configuration inputs
+        plugin_key = rewrite_plugin_key(plugin_key)
         # If such key exists, lookup in plugin directory
         plugin_repo_entry = plugin_directory[plugin_key.to_sym] unless plugin_key.nil?
         # Extract plugin_type based on plugin_directory entry if exists
@@ -120,6 +122,18 @@ class Kaui::AdminTenant < KillBillClient::Model::Tenant
         res
       else
         props['raw_config']
+      end
+    end
+
+    # hack when the plugin name after killbill is not the same as the plugin key, this mainly affects ruby plugin configuration,
+    # as it use the key to retrieve the configuration.
+    def rewrite_plugin_key(plugin_key)
+      if plugin_key.start_with?('paypal')
+        'paypal_express'
+      elsif plugin_key.start_with?('firstdata')
+        'firstdata_e4'
+      else
+        "#{plugin_key}"
       end
     end
   end

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -101,16 +101,16 @@ class Kaui::AdminTenant < KillBillClient::Model::Tenant
     end
 
 
-    def format_plugin_config(plugin_name, plugin_type, props)
+    def format_plugin_config(plugin_key, plugin_type, props)
       return nil unless props.present?
       if plugin_type == 'ruby'
         require 'yaml'
         hsh = {}
-        hsh[plugin_name.to_sym] = {}
+        hsh[plugin_key.to_sym] = {}
         props.each do |k,v|
-          hsh[plugin_name.to_sym][k.to_sym] = v.to_sym
+          hsh[plugin_key.to_sym][k.to_sym] = v.to_sym
         end
-        hsh[plugin_name.to_sym]
+        hsh[plugin_key.to_sym]
         hsh.to_yaml
       elsif plugin_type == 'java'
         res = ""

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -88,11 +88,11 @@ class Kaui::AdminTenant < KillBillClient::Model::Tenant
       end
 
       # Serialize the whole thing a as string of the form:
-      # plugin_key1::key1=value1,key2=value2,..;plugin_key2::...
+      # plugin_key1::key1=value1|key2=value2|..;plugin_key2::...
       tenant_config.map do |plugin_key, props|
         serialized_props = props.inject("") do |s, (k, v)|
           e="#{k.to_s}=#{v.to_s}";
-          s == "" ? s="#{e}" : s="#{s},#{e}";
+          s == "" ? s="#{e}" : s="#{s}|#{e}";
           s
         end
         "#{plugin_key}::#{serialized_props}"

--- a/app/views/kaui/admin_tenants/_form_plugin_config.erb
+++ b/app/views/kaui/admin_tenants/_form_plugin_config.erb
@@ -10,18 +10,33 @@
       <%= form_tag({:action => :upload_plugin_config}, :method => 'post', :multipart => true, :class => 'form-horizontal') do %>
           <%= hidden_field_tag(:id, @tenant.id) %>
           <%= hidden_field_tag(:plugin_name) %>
+          <%= hidden_field_tag(:plugin_key) %>
+          <%= hidden_field_tag(:plugin_type) %>
+
+          <input type="hidden" id="plugin_repository" value="<%= plugin_repository.to_json %>" >
 
           <div id="plugin" class="form-group">
             <%= label_tag :entered_plugin_name, 'Plugin name', :class => 'col-sm-2 control-label' %>
             <div class="col-sm-4">
+              <select class="form-control" id="select_plugin_name"></select>
               <%= text_field_tag :entered_plugin_name, nil, :class => 'form-control', :plugin_config => @plugin_config, :tenant_plugin_config => @tenant_plugin_config %>
-              <div class="text plugin-suggestion text-danger">
-              </div>
+              <div class="text plugin-suggestion text-danger"></div>
             </div>
           </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label toggle-label text-muted">Toggle plugin name input</label>
+            <label class="col-sm-2 toggle-container control-label">
+              <label class="switch">
+                <input id="toggle_input" type="checkbox">
+                <span class="slider round"></span>
+              </label>
+            </label>
+          </div>
+
           <!-- Anchor DIV that gets thrown away when switching plugins -->
           <div id="plugin_config_properties" plugin_name="" class="col-sm-10">
           </div>
+
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <%= submit_tag 'Upload', :class => 'btn btn-default' %>
@@ -31,8 +46,81 @@
     </div>
 <% end %>
 
+<script id="plugin_config_properties_template" type="text/template">
+  {{#plugin_props_with_values}}
+  <div class="form-group">
+    <label class="col-sm-2 control-label" for="{{property}}">{{property_label}}</label>
+    <div class="col-sm-4">
+      {{#is_raw_config}}
+        <textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">{{value}}</textarea>
+      {{/is_raw_config}}
+      {{^is_raw_config}}
+        <input type="text" name="plugin_properties[{{property}}]" id="{{property}}" class="form-control" value="{{value}}" />
+      {{/is_raw_config}}
+    </div>
+  </div>
+  {{/plugin_props_with_values}}
+</script>
+
+<script id="plugin_name_options_template" type="text/template">
+  <option></option>
+  {{#plugin_repository}}
+    {{#start_installed}}<optgroup label="Installed">{{/start_installed}}
+    {{#end_installed}}</optgroup>>{{/end_installed}}
+    <option value="{{plugin_name}}" data-plugin-type="{{plugin_type}}" >
+      {{plugin_key}}
+    </option>
+  {{/plugin_repository}}
+</script>
+
 <%= javascript_tag do %>
     $(document).ready(function() {
+
+        $('#entered_plugin_name').toggle();
+        $('#toggle_input').on('change', function() {
+            $('#select_plugin_name').toggle();
+            $('#entered_plugin_name').toggle();
+            $('.toggle-label').toggleClass('text-muted');
+            $("#plugin_name").val('');
+            $("#plugin_key").val('');
+            $("#plugin_type").val('');
+            $('#entered_plugin_name').val('');
+            $('#select_plugin_name').val('');
+            $('#plugin_config_properties').attr('plugin_name', '');
+            $('#plugin_config_properties').empty();
+
+        });
+
+        $('#select_plugin_name').on('click', function(e) {
+            if (e.target.localName == 'option') {
+                var plugin_name = e.target.value;
+                $("#plugin_name").val(plugin_name);
+                $("#plugin_key").val(e.target.text);
+                $("#plugin_type").val(e.target.dataset['pluginType']);
+                $('#plugin_config_properties').attr('plugin_name', '');
+
+                add_properties_for_plugin(get_plugin_index(plugin_name), plugin_name);
+            }
+        });
+
+        populate_plugin_name_options();
+        function populate_plugin_name_options(){
+            var plugin_repository = JSON.parse($("#plugin_repository").val());
+            for(var idx = 0, size = plugin_repository.length; idx < size; idx++) {
+                if (idx == 0 && plugin_repository[idx].installed) {
+                    plugin_repository[idx]['start_installed'] = true;
+                }
+
+                if (idx > 0 && !plugin_repository[idx].installed && plugin_repository[idx - 1].installed) {
+                    plugin_repository[idx - 1]['end_installed'] = true;
+                    break;
+                }
+            }
+
+            var template = $("#plugin_name_options_template").html();
+            var options_html = Mustache.render( template , { plugin_repository: plugin_repository});
+            $("#select_plugin_name").html(options_html);
+        }
 
         function get_existing_tenant_plugin_properties(entered_plugin_name) {
             var tenant_plugin_properties = $('#entered_plugin_name').attr('tenant_plugin_config');
@@ -56,18 +144,6 @@
                 });
             }
             return res;
-        }
-
-        function get_plugin_index(validated_plugin_info) {
-            var plugin_index = validated_plugin_info.pluginName;
-            var plugin_info = get_selected_plugin_info(plugin_index);
-            // try removing killbill if there is any
-            if (isBlank(plugin_info.type) && plugin_index.indexOf('killbill-') != -1) {
-                plugin_index = (validated_plugin_info.pluginName).replace('killbill-','');
-                plugin_info = get_selected_plugin_info(plugin_index);
-            }
-
-            return isBlank(plugin_info.type) ? validated_plugin_info.pluginName : plugin_index;
         }
 
         function get_selected_plugin_info(plugin_index) {
@@ -95,23 +171,15 @@
             return res;
         }
 
-        function init_plugin_config_source() {
-            var plugin_config_str = $('#entered_plugin_name').attr('plugin_config');
-            var res = []
-            $.map(plugin_config_str.split(";"), function(el) { res.push(el.split(':')[0].split('#')[0]) });
-            return res;
-        }
-
-        function add_properties_for_plugin(entered_plugin_name, validated_plugin_info) {
-            var plugin_index = get_plugin_index(validated_plugin_info);
+        function add_properties_for_plugin(plugin_index, plugin_name) {
             var plugin_info = get_selected_plugin_info(plugin_index);
 
-            if (entered_plugin_name == "") {
+            if (plugin_name == "") {
                 $('#plugin_config_properties').empty();
                 return;
             }
 
-            if ($('#plugin_config_properties').attr('plugin_name') == validated_plugin_info.pluginName) {
+            if ($('#plugin_config_properties').attr('plugin_name') == plugin_name) {
                 /* Already set...*/
                 return;
             }
@@ -122,10 +190,9 @@
             var type = plugin_info['type'];
             var props = plugin_info['props']
 
+            $('#plugin_type').val(type);
             /* Prune the tree to restart from scratch */
             $('#plugin_config_properties').empty();
-
-            $('#plugin_config_properties').append('<input type="hidden" name="plugin_type" id="plugin_type" value="' + type + '" />');
             $('#plugin_config_properties').append('<label class="col-sm-2 control-label" for="plugin_name">Plugin Properties</label>');
             $('#plugin_config_properties').append('<div id="plugin_config_properties_anchor" class="col-sm-offset-2 col-sm-10">');
 
@@ -138,11 +205,9 @@
                 });
             }
 
-            $.each(merged_props_with_values, function(p, v) {
-                add_property_form_entry(format_label(p), p, v);
-            });
+            add_property_form_entry(merged_props_with_values);
 
-            $('#plugin_config_properties').attr('plugin_name', validated_plugin_info.pluginName);
+            $('#plugin_config_properties').attr('plugin_name', plugin_name);
         }
 
         function format_label(input) {
@@ -160,105 +225,84 @@
             return label_name;
         }
 
-        function add_property_form_entry(property_label, property, current_value) {
+        function add_property_form_entry(merged_props_with_values) {
+            var plugin_props_with_values = [];
 
-            var clone = $('#PluginConfig form div').first().clone();
-            clone.children("label").attr('for', property).text(property_label);
-            clone.children("div").first().attr("name", property).attr("id", property);
-            clone.children("div").children("div").hide();
-            var input = clone.children("div").children("input").first();
-            input.removeAttr('autocomplete').removeAttr('plugin_config');
-            if (property == 'raw_config') {
-               var text_area = $('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">');
-               input.replaceWith(text_area);
-               text_area.attr("name", "plugin_properties[" + property + "]")
-                 .attr("id", property)
-                 .attr('class', 'form-control')
-                 .val(current_value);
+            $.each(merged_props_with_values, function(p, v) {
+                plugin_props_with_values.push({ property_label: format_label(p), property: p, value: v, is_raw_config: p == 'raw_config'});
+            });
 
-               input.replaceWith('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">').text(current_value);
-            } else {
-                input.attr("name", "plugin_properties[" + property + "]")
-                 .attr("id", property)
-                 .attr('class', 'form-control')
-                 .val(current_value);
-            }
-
-            /* Attach clone object  */
-            $('#plugin_config_properties_anchor').append(clone);
-
+            var template = $("#plugin_config_properties_template").html();
+            var plugin_props_with_values_html = Mustache.render( template , { plugin_props_with_values: plugin_props_with_values});
+            $("#plugin_config_properties_anchor").html(plugin_props_with_values_html);
         }
 
-
+        // Free text related functions and handlers
+        init_plugin_name_handlers();
         function init_plugin_name_handlers() {
             /* Intercept ENTER and potentially display property form if plugin is know */
             $('#entered_plugin_name').keyup(function (e) {
                 if (e.keyCode === 13) {
-                    validate_plugin_name();
+                    suggest_plugin_name();
                 }
             });
 
             /* Intercept mouseleave and potentially display property form if plugin is know */
             $('#entered_plugin_name').on('mouseleave', function() {
-                validate_plugin_name();
-            });
-
-            /* Attach auto-completion source */
-            $( "#entered_plugin_name" ).autocomplete({
-                                source: init_plugin_config_source(),
-                                classes: {
-                                    "ui-autocomplete": "autocomplete-override"
-                                },
-                                select: function(event, ui){
-                                    validate_plugin_name(ui);
-                                }
+                suggest_plugin_name();
             });
         }
 
-        init_plugin_name_handlers();
+        function get_plugin_index(plugin_name) {
+            var plugin_index = plugin_name;
+            var plugin_info = get_selected_plugin_info(plugin_index);
+            // try removing killbill if there is any
+            if (isBlank(plugin_info.type) && plugin_index.indexOf('killbill-') != -1) {
+                plugin_index = (plugin_name).replace('killbill-','');
+                plugin_info = get_selected_plugin_info(plugin_index);
+            }
 
-        function validation_response(response) {
+            return isBlank(plugin_info.type) ? validated_plugin_info.pluginName : plugin_index;
+        }
+
+        function suggested_response(response) {
             if (!isBlank(response.suggestion)) {
                 $(".plugin-suggestion").html(response.suggestion);
 
                 $("#suggested").click(function(e) {
                     $("#entered_plugin_name").val(e.currentTarget.dataset['pluginName']);
-                    validate_plugin_name();
+                    $("#plugin_key").val(e.currentTarget.dataset['pluginKey']);
+                    $("#plugin_type").val(e.currentTarget.dataset['pluginType']);
+
+                    suggest_plugin_name();
                 });
 
             } else {
                 $(".plugin-suggestion").html('');
             }
 
-            var validated_plugin_info = response.plugin;
-            if (isBlank(validated_plugin_info)) {
-                validated_plugin_info = { pluginName: $('#entered_plugin_name').val() };
-            }
+            var plugin_name = $('#entered_plugin_name').val();
+            var plugin_index = get_plugin_index(plugin_name);
+            $("#plugin_name").val(plugin_name);
 
-            $("#plugin_name").val(validated_plugin_info.pluginName);
-            add_properties_for_plugin($('#entered_plugin_name').val(), validated_plugin_info);
+            add_properties_for_plugin(plugin_index, plugin_name);
         }
 
-        function validate_plugin_name(ui) {
-            var plugin_name;
-            if (ui == undefined) {
-                plugin_name = $("#entered_plugin_name").val();
-            } else {
-                plugin_name = ui.item.value;
-            }
+        function suggest_plugin_name() {
+            var plugin_name = $("#entered_plugin_name").val();
 
             if (isBlank(plugin_name)) {
                 return;
             }
 
             $.ajax({
-                url: '<%= validate_plugin_name_path() %>',
+                url: '<%= suggest_plugin_name_path() %>',
                 type: "GET",
                 dataType: "json",
                 data: {
                     "plugin_name": plugin_name,
                 },
-                success: validation_response
+                success: suggested_response
             });
         }
 

--- a/app/views/kaui/admin_tenants/_form_plugin_config.erb
+++ b/app/views/kaui/admin_tenants/_form_plugin_config.erb
@@ -94,12 +94,13 @@
         $('#select_plugin_name').on('click', function(e) {
             if (e.target.localName == 'option') {
                 var plugin_name = e.target.value;
+                var plugin_key = e.target.text;
                 $("#plugin_name").val(plugin_name);
-                $("#plugin_key").val(e.target.text);
+                $("#plugin_key").val(plugin_key);
                 $("#plugin_type").val(e.target.dataset['pluginType']);
                 $('#plugin_config_properties').attr('plugin_name', '');
 
-                add_properties_for_plugin(get_plugin_index(plugin_name), plugin_name);
+                add_properties_for_plugin(plugin_key, plugin_name);
             }
         });
 
@@ -171,8 +172,8 @@
             return res;
         }
 
-        function add_properties_for_plugin(plugin_index, plugin_name) {
-            var plugin_info = get_selected_plugin_info(plugin_index);
+        function add_properties_for_plugin(plugin_key, plugin_name) {
+            var plugin_info = get_selected_plugin_info(plugin_key);
 
             if (plugin_name == "") {
                 $('#plugin_config_properties').empty();
@@ -185,7 +186,7 @@
             }
 
             /* Retrieve existing plugin properties for this tenant */
-            var existing_props = get_existing_tenant_plugin_properties(plugin_index);
+            var existing_props = get_existing_tenant_plugin_properties(plugin_key);
 
             var type = plugin_info['type'];
             var props = plugin_info['props']
@@ -253,18 +254,6 @@
             });
         }
 
-        function get_plugin_index(plugin_name) {
-            var plugin_index = plugin_name;
-            var plugin_info = get_selected_plugin_info(plugin_index);
-            // try removing killbill if there is any
-            if (isBlank(plugin_info.type) && plugin_index.indexOf('killbill-') != -1) {
-                plugin_index = (plugin_name).replace('killbill-','');
-                plugin_info = get_selected_plugin_info(plugin_index);
-            }
-
-            return isBlank(plugin_info.type) ? validated_plugin_info.pluginName : plugin_index;
-        }
-
         function suggested_response(response) {
             if (!isBlank(response.suggestion)) {
                 $(".plugin-suggestion").html(response.suggestion);
@@ -282,10 +271,10 @@
             }
 
             var plugin_name = $('#entered_plugin_name').val();
-            var plugin_index = get_plugin_index(plugin_name);
+            var plugin_key = $("#plugin_key").val();
             $("#plugin_name").val(plugin_name);
 
-            add_properties_for_plugin(plugin_index, plugin_name);
+            add_properties_for_plugin(isBlank(plugin_key) ? plugin_name : plugin_key, plugin_name);
         }
 
         function suggest_plugin_name() {

--- a/app/views/kaui/admin_tenants/_form_plugin_config.erb
+++ b/app/views/kaui/admin_tenants/_form_plugin_config.erb
@@ -9,15 +9,18 @@
 
       <%= form_tag({:action => :upload_plugin_config}, :method => 'post', :multipart => true, :class => 'form-horizontal') do %>
           <%= hidden_field_tag(:id, @tenant.id) %>
+          <%= hidden_field_tag(:plugin_name) %>
 
-          <div class="form-group">
-            <%= label_tag :plugin_name, 'Plugin name', :class => 'col-sm-2 control-label' %>
+          <div id="plugin" class="form-group">
+            <%= label_tag :entered_plugin_name, 'Plugin name', :class => 'col-sm-2 control-label' %>
             <div class="col-sm-4">
-              <%= text_field_tag :plugin_name, nil, :class => 'form-control', :plugin_config => @plugin_config, :tenant_plugin_config => @tenant_plugin_config %>
+              <%= text_field_tag :entered_plugin_name, nil, :class => 'form-control', :plugin_config => @plugin_config, :tenant_plugin_config => @tenant_plugin_config %>
+              <div class="text plugin-suggestion text-danger">
+              </div>
             </div>
           </div>
           <!-- Anchor DIV that gets thrown away when switching plugins -->
-          <div id="plugin_config_properties" , plugin_name="" , class="col-sm-10">
+          <div id="plugin_config_properties" plugin_name="" class="col-sm-10">
           </div>
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
@@ -29,171 +32,235 @@
 <% end %>
 
 <%= javascript_tag do %>
+    $(document).ready(function() {
 
-function get_existing_tenant_plugin_properties(plugin_name) {
+        function get_existing_tenant_plugin_properties(entered_plugin_name) {
+            var tenant_plugin_properties = $('#entered_plugin_name').attr('tenant_plugin_config');
+            var res = {}
+            if (tenant_plugin_properties != undefined) {
+                $.each(tenant_plugin_properties.split(';'), function(idx, el) {
+                    var el_parts = el.split('::');
+                    var el_plugin_name = el_parts[0];
+                    var el_props = el_parts[1];
+                    if (el_plugin_name === entered_plugin_name) {
+                        if (el_props.split('=')[0] == 'raw_config') {
+                            res['raw_config'] = el_props.substr(11);
+                        } else {
+                            $.map(el_props.split('|'), function(el) {
+                                var parts = el.split('=');
+                                res[parts[0]] = parts[1];
+                            });
+                        }
+                        return false;
+                    }
+                });
+            }
+            return res;
+        }
 
-    var tenant_plugin_properties = $('#plugin_name').attr('tenant_plugin_config');
-    var res = {}
-    if (tenant_plugin_properties != undefined) {
-        $.each(tenant_plugin_properties.split(';'), function(idx, el) {
-            var el_parts = el.split('::');
-            var el_plugin_name = el_parts[0];
-            var el_props = el_parts[1];
-            if (el_plugin_name == plugin_name) {
-                if (el_props.split('=')[0] == 'raw_config') {
-                    res['raw_config'] = el_props.substr(11);
-                } else {
-                    $.map(el_props.split(','), function(el) {
-                        var parts = el.split('=');
-                        res[parts[0]] = parts[1];
-                    });
+        function get_plugin_index(validated_plugin_info) {
+            var plugin_index = validated_plugin_info.pluginName;
+            var plugin_info = get_selected_plugin_info(plugin_index);
+            // try removing killbill if there is any
+            if (isBlank(plugin_info.type) && plugin_index.indexOf('killbill-') != -1) {
+                plugin_index = (validated_plugin_info.pluginName).replace('killbill-','');
+                plugin_info = get_selected_plugin_info(plugin_index);
+            }
+
+            return isBlank(plugin_info.type) ? validated_plugin_info.pluginName : plugin_index;
+        }
+
+        function get_selected_plugin_info(plugin_index) {
+            var plugin_config_str = $('#entered_plugin_name').attr('plugin_config');
+            var res = {}
+            /* Deserialize plugin/properties (see AdminTenant model)*/
+            $.each(plugin_config_str.split(';'), function(idx, el) {
+                var el_parts = el.split(':');
+                var el_parts_key = el_parts[0].split('#');
+                var el_plugin_name = el_parts_key[0];
+                var el_plugin_type = el_parts_key[1];
+                var el_plugin_props = el_parts[1];
+                if (el_plugin_name == plugin_index) {
+                    res['type'] = el_plugin_type;
+                    res['props'] = el_plugin_props == "" ? [] : (el_plugin_type == "" ? ['raw_config'] : el_plugin_props.split(','));
+                    return false;
                 }
-                return false;
+            });
+
+            if (res['props'] == undefined) {
+                res['type'] = '';
+                res['props'] = ['raw_config'];
             }
-        });
-    }
-    return res;
-}
 
-function get_selected_plugin_info() {
-    var plugin_name = $('#plugin_name').val();
-    var plugin_config_str = $('#plugin_name').attr('plugin_config');
-
-    var res = {}
-    /* Deserialize plugin/properties (see AdminTenant model)*/
-    $.each(plugin_config_str.split(';'), function(idx, el) {
-        var el_parts = el.split(':');
-        var el_parts_key = el_parts[0].split('#');
-        var el_plugin_name = el_parts_key[0];
-        var el_plugin_type = el_parts_key[1];
-        var el_plugin_props = el_parts[1];
-        if (el_plugin_name == plugin_name) {
-            res['type'] = el_plugin_type;
-            res['props'] = el_plugin_props == "" ? [] : (el_plugin_type == "" ? ['raw_config'] : el_plugin_props.split(','));
-            return false;
+            return res;
         }
-    });
 
-    if (res['props'] == undefined) {
-        res['type'] = '';
-        res['props'] = ['raw_config'];
-    }
+        function init_plugin_config_source() {
+            var plugin_config_str = $('#entered_plugin_name').attr('plugin_config');
+            var res = []
+            $.map(plugin_config_str.split(";"), function(el) { res.push(el.split(':')[0].split('#')[0]) });
+            return res;
+        }
 
-    return res;
-}
+        function add_properties_for_plugin(entered_plugin_name, validated_plugin_info) {
+            var plugin_index = get_plugin_index(validated_plugin_info);
+            var plugin_info = get_selected_plugin_info(plugin_index);
 
-function init_plugin_config_source() {
-    var plugin_config_str = $('#plugin_name').attr('plugin_config');
-    var res = []
-    $.map(plugin_config_str.split(";"), function(el) { res.push(el.split(':')[0].split('#')[0]) });
-    return res;
-}
-
-function add_properties_for_plugin(plugin_name, plugin_info) {
-
-    if (plugin_name == "") {
-        $('#plugin_config_properties').empty();
-        return;
-    }
-
-    if ($('#plugin_config_properties').attr('plugin_name') == plugin_name) {
-        /* Already set...*/
-        return;
-    }
-
-    var type = plugin_info['type'];
-    var props = plugin_info['props']
-
-    /* Prune the tree to restart from scratch */
-    $('#plugin_config_properties').empty();
-
-    $('#plugin_config_properties').append('<input type="hidden" name="plugin_type" id="plugin_type" value="' + type + '" />');
-    $('#plugin_config_properties').append('<label class="col-sm-2 control-label" for="plugin_name">Plugin Properties</label>');
-    $('#plugin_config_properties').append('<div id="plugin_config_properties_anchor" class="col-sm-offset-2 col-sm-10">');
-
-    /* Retrieve existing plugin properties for this tenant */
-    var existing_props = get_existing_tenant_plugin_properties(plugin_name);
-
-    var merged_props_with_values = existing_props;
-    if (props != undefined) {
-        $.each(props, function(idx, p) {
-            if (merged_props_with_values[p] == undefined) {
-               merged_props_with_values[p] = '';
+            if (entered_plugin_name == "") {
+                $('#plugin_config_properties').empty();
+                return;
             }
-        });
-    }
 
-    $.each(merged_props_with_values, function(p, v) {
-        add_property_form_entry(format_label(p), p, v);
-    });
+            if ($('#plugin_config_properties').attr('plugin_name') == validated_plugin_info.pluginName) {
+                /* Already set...*/
+                return;
+            }
 
-    $('#plugin_config_properties').attr('plugin_name', plugin_name);
-}
+            /* Retrieve existing plugin properties for this tenant */
+            var existing_props = get_existing_tenant_plugin_properties(plugin_index);
 
-function format_label(input) {
-    /* Keep latest piece of a system property to keep it short */
-    var label_name = input.split('.').pop();
-    /* Replace underscore with comma */
-    label_name = label_name.replace(/_/g, ',');
-    /* Replace uppercase with comma + uppercase */
-    label_name = label_name.replace(/([A-Z]+)/g, ",$1");
-    /* Split name make sure each word starts with Uppercase */
-    var tmp1 = label_name.split(',');
-    var label_name_array = [];
-    $.map(tmp1, function(el) { label_name_array.push(el.charAt(0).toUpperCase() + el.slice(1)) });
-    label_name = label_name_array.join(' ');
-    return label_name;
-}
+            var type = plugin_info['type'];
+            var props = plugin_info['props']
 
-function add_property_form_entry(property_label, property, current_value) {
+            /* Prune the tree to restart from scratch */
+            $('#plugin_config_properties').empty();
 
-    var clone = $('#PluginConfig form div').first().clone();
-    clone.children("label").attr('for', property).text(property_label);
-    clone.children("div").first().attr("name", property).attr("id", property);
-    var input = clone.children("div").children("input").first();
-    input.removeAttr('autocomplete').removeAttr('plugin_config');
-    if (property == 'raw_config') {
-       var text_area = $('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">');
-       input.replaceWith(text_area);
-       text_area.attr("name", "plugin_properties[" + property + "]")
-         .attr("id", property)
-         .attr('class', 'form-control')
-         .val(current_value);
+            $('#plugin_config_properties').append('<input type="hidden" name="plugin_type" id="plugin_type" value="' + type + '" />');
+            $('#plugin_config_properties').append('<label class="col-sm-2 control-label" for="plugin_name">Plugin Properties</label>');
+            $('#plugin_config_properties').append('<div id="plugin_config_properties_anchor" class="col-sm-offset-2 col-sm-10">');
 
-       input.replaceWith('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">').text(current_value);
-    } else {
-        input.attr("name", "plugin_properties[" + property + "]")
-         .attr("id", property)
-         .attr('class', 'form-control')
-         .val(current_value);
-   }
+            var merged_props_with_values = existing_props;
+            if (props != undefined) {
+                $.each(props, function(idx, p) {
+                    if (merged_props_with_values[p] == undefined) {
+                       merged_props_with_values[p] = '';
+                    }
+                });
+            }
 
-    /* Attach clone object  */
-    $('#plugin_config_properties_anchor').append(clone);
+            $.each(merged_props_with_values, function(p, v) {
+                add_property_form_entry(format_label(p), p, v);
+            });
 
-}
-
-
-function init_plugin_name_handlers() {
-    /* Intercept ENTER and potentially display property form if plugin is know */
-    $('#plugin_name').keyup(function (e) {
-        if (e.keyCode === 13) {
-        add_properties_for_plugin($('#plugin_name').val(), get_selected_plugin_info());
+            $('#plugin_config_properties').attr('plugin_name', validated_plugin_info.pluginName);
         }
-    });
 
-    /* Intercept mouseleave and potentially display property form if plugin is know */
-    $('#plugin_name').on('mouseleave', function() {
-        add_properties_for_plugin($('#plugin_name').val(), get_selected_plugin_info());
-    });
+        function format_label(input) {
+            /* Keep latest piece of a system property to keep it short */
+            var label_name = input.split('.').pop();
+            /* Replace underscore with comma */
+            label_name = label_name.replace(/_/g, ',');
+            /* Replace uppercase with comma + uppercase */
+            label_name = label_name.replace(/([A-Z]+)/g, ",$1");
+            /* Split name make sure each word starts with Uppercase */
+            var tmp1 = label_name.split(',');
+            var label_name_array = [];
+            $.map(tmp1, function(el) { label_name_array.push(el.charAt(0).toUpperCase() + el.slice(1)) });
+            label_name = label_name_array.join(' ');
+            return label_name;
+        }
 
-    /* Attach auto-completion source */
-    $('#plugin_name').autocomplete({
-    source: init_plugin_config_source()
-    });
-}
+        function add_property_form_entry(property_label, property, current_value) {
 
-$(document).ready(function() {
-    init_plugin_name_handlers();
+            var clone = $('#PluginConfig form div').first().clone();
+            clone.children("label").attr('for', property).text(property_label);
+            clone.children("div").first().attr("name", property).attr("id", property);
+            clone.children("div").children("div").hide();
+            var input = clone.children("div").children("input").first();
+            input.removeAttr('autocomplete').removeAttr('plugin_config');
+            if (property == 'raw_config') {
+               var text_area = $('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">');
+               input.replaceWith(text_area);
+               text_area.attr("name", "plugin_properties[" + property + "]")
+                 .attr("id", property)
+                 .attr('class', 'form-control')
+                 .val(current_value);
+
+               input.replaceWith('<textarea name="plugin_properties[raw_config]" id="raw_config" rows="10" class="form-control">').text(current_value);
+            } else {
+                input.attr("name", "plugin_properties[" + property + "]")
+                 .attr("id", property)
+                 .attr('class', 'form-control')
+                 .val(current_value);
+            }
+
+            /* Attach clone object  */
+            $('#plugin_config_properties_anchor').append(clone);
+
+        }
+
+
+        function init_plugin_name_handlers() {
+            /* Intercept ENTER and potentially display property form if plugin is know */
+            $('#entered_plugin_name').keyup(function (e) {
+                if (e.keyCode === 13) {
+                    validate_plugin_name();
+                }
+            });
+
+            /* Intercept mouseleave and potentially display property form if plugin is know */
+            $('#entered_plugin_name').on('mouseleave', function() {
+                validate_plugin_name();
+            });
+
+            /* Attach auto-completion source */
+            $( "#entered_plugin_name" ).autocomplete({
+                                source: init_plugin_config_source(),
+                                classes: {
+                                    "ui-autocomplete": "autocomplete-override"
+                                },
+                                select: function(event, ui){
+                                    validate_plugin_name(ui);
+                                }
+            });
+        }
+
+        init_plugin_name_handlers();
+
+        function validation_response(response) {
+            if (!isBlank(response.suggestion)) {
+                $(".plugin-suggestion").html(response.suggestion);
+
+                $("#suggested").click(function(e) {
+                    $("#entered_plugin_name").val(e.currentTarget.dataset['pluginName']);
+                    validate_plugin_name();
+                });
+
+            } else {
+                $(".plugin-suggestion").html('');
+            }
+
+            var validated_plugin_info = response.plugin;
+            if (isBlank(validated_plugin_info)) {
+                validated_plugin_info = { pluginName: $('#entered_plugin_name').val() };
+            }
+
+            $("#plugin_name").val(validated_plugin_info.pluginName);
+            add_properties_for_plugin($('#entered_plugin_name').val(), validated_plugin_info);
+        }
+
+        function validate_plugin_name(ui) {
+            var plugin_name;
+            if (ui == undefined) {
+                plugin_name = $("#entered_plugin_name").val();
+            } else {
+                plugin_name = ui.item.value;
+            }
+
+            if (isBlank(plugin_name)) {
+                return;
+            }
+
+            $.ajax({
+                url: '<%= validate_plugin_name_path() %>',
+                type: "GET",
+                dataType: "json",
+                data: {
+                    "plugin_name": plugin_name,
+                },
+                success: validation_response
+            });
+        }
+
 });
 <% end %>

--- a/app/views/kaui/admin_tenants/_form_plugin_config.erb
+++ b/app/views/kaui/admin_tenants/_form_plugin_config.erb
@@ -22,15 +22,13 @@
               <%= text_field_tag :entered_plugin_name, nil, :class => 'form-control', :plugin_config => @plugin_config, :tenant_plugin_config => @tenant_plugin_config %>
               <div class="text plugin-suggestion text-danger"></div>
             </div>
-          </div>
-          <div class="form-group">
-            <label class="col-sm-2 control-label toggle-label text-muted">Toggle plugin name input</label>
-            <label class="col-sm-2 toggle-container control-label">
+            <label class="col-sm-1 toggle-container control-label">
               <label class="switch">
                 <input id="toggle_input" type="checkbox">
                 <span class="slider round"></span>
               </label>
             </label>
+            <label class="col-sm-3 control-label toggle-label text-muted">or toggle plugin name input</label>
           </div>
 
           <!-- Anchor DIV that gets thrown away when switching plugins -->
@@ -113,7 +111,7 @@
                 }
 
                 if (idx > 0 && !plugin_repository[idx].installed && plugin_repository[idx - 1].installed) {
-                    plugin_repository[idx - 1]['end_installed'] = true;
+                    plugin_repository[idx]['end_installed'] = true;
                     break;
                 }
             }
@@ -173,10 +171,12 @@
         }
 
         function add_properties_for_plugin(plugin_key, plugin_name) {
+            console.log(plugin_key, plugin_name);
             var plugin_info = get_selected_plugin_info(plugin_key);
 
-            if (plugin_name == "") {
+            if (isBlank(plugin_name)) {
                 $('#plugin_config_properties').empty();
+                $('#plugin_config_properties').attr('plugin_name', '');
                 return;
             }
 
@@ -243,6 +243,7 @@
         function init_plugin_name_handlers() {
             /* Intercept ENTER and potentially display property form if plugin is know */
             $('#entered_plugin_name').keyup(function (e) {
+                e.preventDefault();
                 if (e.keyCode === 13) {
                     suggest_plugin_name();
                 }
@@ -259,11 +260,15 @@
                 $(".plugin-suggestion").html(response.suggestion);
 
                 $("#suggested").click(function(e) {
-                    $("#entered_plugin_name").val(e.currentTarget.dataset['pluginName']);
-                    $("#plugin_key").val(e.currentTarget.dataset['pluginKey']);
+                    var plugin_name = e.currentTarget.dataset['pluginName'];
+                    var plugin_key = e.currentTarget.dataset['pluginKey'];
+
+                    $("#entered_plugin_name").val(plugin_name);
+                    $("#plugin_key").val(plugin_key);
                     $("#plugin_type").val(e.currentTarget.dataset['pluginType']);
 
-                    suggest_plugin_name();
+                    $(".plugin-suggestion").html('');
+                    add_properties_for_plugin(isBlank(plugin_key) ? plugin_name : plugin_key, plugin_name);
                 });
 
             } else {
@@ -279,6 +284,7 @@
 
         function suggest_plugin_name() {
             var plugin_name = $("#entered_plugin_name").val();
+            $("#plugin_key").val(plugin_name);
 
             if (isBlank(plugin_name)) {
                 return;

--- a/app/views/kaui/audit_logs/_show_history_modal.html.erb
+++ b/app/views/kaui/audit_logs/_show_history_modal.html.erb
@@ -132,24 +132,6 @@
             }
         }
 
-        function isNullOrUndefined(value) {
-            if (value == undefined || value == null) {
-                return true;
-            }
-            return false;
-        }
-
-        function isBlank(value) {
-            if (isNullOrUndefined(value)) {
-                return true;
-            }
-
-            if (jQuery.type(value) === "string" && value.trim().length == 0) {
-                return true;
-            }
-            return false;
-        }
-
         function loadHistory(url) {
             var object_id = $("#objectId").val();
             var object_type = $("#objectType").val();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,7 +185,7 @@ Kaui::Engine.routes.draw do
     match '/add_allowed_user' => 'admin_tenants#add_allowed_user', :via => :put, :as => 'add_allowed_user'
     match '/allowed_users' => 'admin_tenants#allowed_users', :via => :get, :as => 'admin_tenant_allowed_users'
     match '/catalog_by_effective_date' => 'admin_tenants#catalog_by_effective_date', :via => :get, :as => 'catalog_by_effective_date'
-    match '/validate_plugin_name' => 'admin_tenants#validate_plugin_name', :via => :get, :as => 'validate_plugin_name'
+    match '/suggest_plugin_name' => 'admin_tenants#suggest_plugin_name', :via => :get, :as => 'suggest_plugin_name'
   end
   resources :admin_tenants, :only => [ :index, :new, :create, :show ]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Kaui::Engine.routes.draw do
     match '/add_allowed_user' => 'admin_tenants#add_allowed_user', :via => :put, :as => 'add_allowed_user'
     match '/allowed_users' => 'admin_tenants#allowed_users', :via => :get, :as => 'admin_tenant_allowed_users'
     match '/catalog_by_effective_date' => 'admin_tenants#catalog_by_effective_date', :via => :get, :as => 'catalog_by_effective_date'
+    match '/validate_plugin_name' => 'admin_tenants#validate_plugin_name', :via => :get, :as => 'validate_plugin_name'
   end
   resources :admin_tenants, :only => [ :index, :new, :create, :show ]
 

--- a/test/functional/kaui/admin_tenants_controller_test.rb
+++ b/test/functional/kaui/admin_tenants_controller_test.rb
@@ -284,6 +284,12 @@ class Kaui::AdminTenantsControllerTest < Kaui::FunctionalTestHelper
 
   end
 
+  test 'should suggest a plugin name' do
+    get :validate_plugin_name, :plugin_name => 'paypa'
+    assert_response :success
+    assert_equal JSON[@response.body]['suggestion'], "Official plugin not found, did you mean '<a id=\"suggested\" data-plugin-name=\"killbill-paypal-express\" data-plugin-key=\"paypal\" href=\"#\">killbill-paypal-express</a>'?"
+  end
+
   private
 
   def create_kaui_tenant

--- a/test/functional/kaui/admin_tenants_controller_test.rb
+++ b/test/functional/kaui/admin_tenants_controller_test.rb
@@ -285,9 +285,15 @@ class Kaui::AdminTenantsControllerTest < Kaui::FunctionalTestHelper
   end
 
   test 'should suggest a plugin name' do
-    get :validate_plugin_name, :plugin_name => 'paypa'
+    plugin_anchor = "'<a id=\"suggested\" data-plugin-name=\"killbill-paypal-express\" data-plugin-key=\"paypal\" href=\"#\">killbill-paypal-express</a>'"
+
+    get :validate_plugin_name, :plugin_name => 'paypal-express'
     assert_response :success
-    assert_equal JSON[@response.body]['suggestion'], "Official plugin not found, did you mean '<a id=\"suggested\" data-plugin-name=\"killbill-paypal-express\" data-plugin-key=\"paypal\" href=\"#\">killbill-paypal-express</a>'?"
+    assert_equal JSON[@response.body]['suggestion'], "Similar plugin already installed: #{plugin_anchor}"
+
+    get :validate_plugin_name, :plugin_name => 'pypl'
+    assert_response :success
+    assert_equal JSON[@response.body]['suggestion'], "Did you mean #{plugin_anchor}?"
   end
 
   private

--- a/test/functional/kaui/admin_tenants_controller_test.rb
+++ b/test/functional/kaui/admin_tenants_controller_test.rb
@@ -92,7 +92,7 @@ class Kaui::AdminTenantsControllerTest < Kaui::FunctionalTestHelper
     stripe_yml = YAML.load_file(File.join(self.class.fixture_path, 'stripe.yml'))[:stripe]
     stripe_yml.stringify_keys!
     stripe_yml.each { |k, v| stripe_yml[k] = v.to_s }
-    post :upload_plugin_config, :id => tenant.id, :plugin_name => 'killbill-stripe', :plugin_type => 'ruby', :plugin_properties => stripe_yml
+    post :upload_plugin_config, :id => tenant.id, :plugin_name => 'killbill-stripe', :plugin_key => 'stripe', :plugin_type => 'ruby', :plugin_properties => stripe_yml
 
     assert_redirected_to admin_tenant_path(tenant.id)
     assert_equal 'Config for plugin was successfully uploaded', flash[:notice]

--- a/test/unit/kaui/admin_tenant_test.rb
+++ b/test/unit/kaui/admin_tenant_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class Kaui::AdminTenantTest < ActiveSupport::TestCase
+
+  PLUGINS_INFO = '[{"bundleSymbolicName":"org.kill-bill.billing.plugin.java.analytics-plugin","pluginKey":"analytics","pluginName":"analytics-plugin","version":"5.0.3","state":"RUNNING","isSelectedForStart":true,"services":[{"serviceTypeName":"javax.servlet.Servlet","registrationName":"killbill-analytics"}]},{"bundleSymbolicName":"org.kill-bill.billing.plugin.java.killbill-email-notifications-plugin","pluginKey":"killbill-email-notifications","pluginName":"killbill-email-notifications","version":"0.3.1-SNAPSHOT","state":"RUNNING","isSelectedForStart":true,"services":[{"serviceTypeName":"javax.servlet.Servlet","registrationName":"killbill-email-notifications"}]},{"bundleSymbolicName":"org.kill-bill.billing.killbill-platform-osgi-bundles-jruby-2","pluginKey":"kpm","pluginName":"killbill-kpm","version":"1.2.3","state":"RUNNING","isSelectedForStart":true,"services":[{"serviceTypeName":"javax.servlet.Servlet","registrationName":"killbill-kpm"}]},{"bundleSymbolicName":null,"pluginKey":"paypal","pluginName":"killbill-paypal-express","version":"5.0.7","state":"STOPPED","isSelectedForStart":true,"services":[]}]'
+
+  test 'can split camel dash underscore space strings' do
+    adminTenantController = Kaui::AdminTenantsController.new
+
+    string = 'camelCaseString'
+    splitted = adminTenantController.send(:split_camel_dash_underscore_space, string)
+    assert_equal 3, splitted.count
+
+    string = 'this-is-a-string-to-split'
+    splitted = adminTenantController.send(:split_camel_dash_underscore_space, string)
+    assert_split(splitted)
+
+    string = 'this_is_a_string_to_split'
+    splitted = adminTenantController.send(:split_camel_dash_underscore_space, string)
+    assert_split(splitted)
+
+    string = 'this is a string to split'
+    splitted = adminTenantController.send(:split_camel_dash_underscore_space, string)
+    assert_split(splitted)
+
+    string = 'this-IsA string_to-split'
+    splitted = adminTenantController.send(:split_camel_dash_underscore_space, string)
+    assert_split(splitted)
+
+  end
+
+  test 'can do a fuzzy match of a plugin to suggest an already installed plugin' do
+    plugins_info = plugins_info()
+    adminTenantController = Kaui::AdminTenantsController.new
+
+    %w(killbill-paypal express paypal-express pypl).each do |plugin_name|
+      found_plugin, weights = adminTenantController.send(:fuzzy_match, plugin_name, plugins_info)
+      assert_nil(found_plugin)
+      assert_equal weights[0][:plugin_name], 'killbill-paypal-express'
+    end
+
+    plugin_name = 'email'
+    found_plugin, weights = adminTenantController.send(:fuzzy_match, plugin_name, plugins_info)
+    assert_nil(found_plugin)
+    assert_equal weights[0][:plugin_name], 'killbill-email-notifications'
+
+  end
+
+  private
+
+  def plugins_info
+    plugins_info = []
+    hash_plugin_info = JSON.parse(PLUGINS_INFO)
+    hash_plugin_info.each { |plugin| plugins_info << KillBillClient::Model::PluginInfoAttributes.new(plugin)}
+    plugins_info
+  end
+
+  def assert_split(splitted)
+    assert_equal 6, splitted.count
+    assert_equal 'this', splitted[0]
+    assert_equal 'is', splitted[1]
+    assert_equal 'a', splitted[2]
+    assert_equal 'string', splitted[3]
+    assert_equal 'to', splitted[4]
+    assert_equal 'split', splitted[5]
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10049037/39823508-3301c4b2-537b-11e8-9be9-7ee743303c79.png)

- The entered plugin name will be validated, if the value is valid the response will have the official plugin name, if is not, it will return a suggestion.
- The clicked value of the autocomplete will be validated as the previous point. 
- The suggestion is clickable, so if clicked it will set the plugin name with the suggested information.
- The inputs will stay the same as before showing a textbox for unknown plugin and custom inputs for known plugins.
- The key name of the source of truth for PayPal must be updated from `paypal` to `paypal-express`: https://raw.githubusercontent.com/killbill/killbill-cloud/master/kpm/lib/kpm/plugins_directory.yml. This is needed to allow the inputs related to paypal be shown and not the raw textbox.

