### PR TITLE
The DATABASE_URL must be set for rails db:migrate to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can run Kaui locally by using the test/dummy app provided:
 
 ```
 export RAILS_ENV=development
+export DATABASE_URL=mysql://root:killbill@<MySQL Host IP>/killbill
 bundle install
 rails db:migrate
 rails s


### PR DESCRIPTION
The DATABASE_URL must be set for rails db:migrate to run.