### PR TITLE
Update credits label on invoice details page to say Resulting available credits

### DIFF
--- a/app/views/kaui/invoices/_invoice_table.html.erb
+++ b/app/views/kaui/invoices/_invoice_table.html.erb
@@ -134,7 +134,7 @@
       <td><%= humanized_money_with_symbol @invoice.amount_to_money %> (<%= @invoice.currency %>)</td>
     </tr>
     <tr>
-      <th>Credits:</th>
+      <th>Resulting available credits:</th>
       <td><%= humanized_money_with_symbol @invoice.credit_adjustment_to_money %> (<%= @invoice.currency %>)</td>
     </tr>
     <tr>


### PR DESCRIPTION
Update label on invoice details page to say Resulting available credits in summary section to avoid confusion with credits applied.