### PR TITLE
check_object_exist method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,10 +18,10 @@ if defined?(JRUBY_VERSION)
   end
 end
 
+gem 'gon'
 #gem 'killbill-client', :path => '../killbill-client-ruby'
 #gem 'killbill-client', :git => 'https://github.com/killbill/killbill-client-ruby.git', :branch => 'work-for-release-0.21.x'
 #gem 'killbill-client', '3.2.0'
 
 #gem 'kenui', :path => '../killbill-email-notifications-ui'
 #gem 'kenui', :git => 'https://github.com/killbill/killbill-email-notifications-ui.git', :branch => 'work-for-release-0.21.x'
-

--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,12 @@ if defined?(JRUBY_VERSION)
       gem 'activerecord-jdbcpostgresql-adapter'
       # Pulls activerecord-jdbc-adapter and jdbc-sqlite3
       gem 'activerecord-jdbcsqlite3-adapter'
+      gem 'gon'
     end
   end
 end
 
-gem 'gon'
+
 #gem 'killbill-client', :path => '../killbill-client-ruby'
 #gem 'killbill-client', :git => 'https://github.com/killbill/killbill-client-ruby.git', :branch => 'work-for-release-0.21.x'
 #gem 'killbill-client', '3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ if defined?(JRUBY_VERSION)
       gem 'activerecord-jdbcpostgresql-adapter'
       # Pulls activerecord-jdbc-adapter and jdbc-sqlite3
       gem 'activerecord-jdbcsqlite3-adapter'
-      gem 'gon'
     end
   end
 end

--- a/app/assets/javascripts/kaui/kaui.js
+++ b/app/assets/javascripts/kaui/kaui.js
@@ -118,6 +118,7 @@ jQuery(document).ready(function ($) {
     /*
      * Calculate first name length
      */
+
     $('#account_name').on('keyup', function(e){
         set_first_name_length($(this).val());
     });
@@ -137,6 +138,36 @@ jQuery(document).ready(function ($) {
             $('#account_first_name_length').val('');
         }
     }
+
+    $('#custom_field_object_id').on('keyup', function(e) {
+
+      var uuid = $(this).val();
+
+      $.ajax({
+        url: gon.url,
+        type: "GET",
+        dataType: "json",
+        data: {
+          uuid: $(this).val()
+        },
+        success: function(data) {
+          if (data.status == 200) {
+
+            var msg = uuid + ' - ' + data["message"];
+            ajaxCloseAlert()
+            ajaxInfoAlert(msg, 4000);
+
+          } else {
+            var msg = uuid + ' - ' + data["message"];
+            ajaxCloseAlert()
+            ajaxErrorAlert(msg);
+          }
+        }
+      });
+
+
+    });
+
 
     /*
      *  Validate external key

--- a/app/controllers/kaui/custom_fields_controller.rb
+++ b/app/controllers/kaui/custom_fields_controller.rb
@@ -43,6 +43,9 @@ class Kaui::CustomFieldsController < Kaui::EngineController
 
   def new
     @custom_field = Kaui::CustomField.new
+    cf_url = custom_fields_check_object_exist_path
+
+    gon.url = "#{cf_url}"
   end
 
   def check_object_exist

--- a/app/controllers/kaui/custom_fields_controller.rb
+++ b/app/controllers/kaui/custom_fields_controller.rb
@@ -47,17 +47,19 @@ class Kaui::CustomFieldsController < Kaui::EngineController
 
   def check_object_exist
 
-    param_uuid = params[:uuid] || []
+    param_uuid = params[:uuid]
 
-    begin
-      test_uuid = Kaui::InvoiceItem.new(:invoice_item_id => param_uuid)
-    rescue StandardError
-    ensure
-      if !test_uuid.blank? && (test_uuid.invoice_item_id == param_uuid)
-        msg = { status: '200', message: 'UUID do exist in INVOICE ITEMS object database.' }
-        render json: msg and return
-      end
-    end
+    # to-do
+    # begin
+    #   test_uuid = Kaui::InvoiceItem.new(:invoice_item_id => param_uuid)
+    #   ap test_uuid and return
+    # rescue StandardError
+    # ensure
+    #   if !test_uuid.blank? && (test_uuid.invoice_item_id == param_uuid)
+    #     msg = { status: '200', message: 'UUID do exist in INVOICE ITEMS object database.' }
+    #     render json: msg and return
+    #   end
+    # end
 
     begin
       test_uuid = Kaui::Account.find_by_id_or_key(param_uuid, false, false, options_for_klient)

--- a/app/controllers/kaui/custom_fields_controller.rb
+++ b/app/controllers/kaui/custom_fields_controller.rb
@@ -1,6 +1,10 @@
 class Kaui::CustomFieldsController < Kaui::EngineController
 
   def index
+
+
+
+
     @search_query = params[:q]
 
     @ordering = params[:ordering] || (@search_query.blank? ? 'desc' : 'asc')
@@ -41,6 +45,89 @@ class Kaui::CustomFieldsController < Kaui::EngineController
     @custom_field = Kaui::CustomField.new
   end
 
+  def check_object_exist
+
+    param_uuid = params[:uuid] || []
+
+    begin
+      test_uuid = Kaui::InvoiceItem.new(:invoice_item_id => param_uuid)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.invoice_item_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in INVOICE ITEMS object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      test_uuid = Kaui::Account.find_by_id_or_key(param_uuid, false, false, options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.account_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in ACCOUNT object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      test_uuid = Kaui::Bundle.find_by_id_or_key(param_uuid, options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.bundle_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in BUNDLE object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      test_uuid = Kaui::Subscription.find_by_id(param_uuid, options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.subscription_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in SUBSCRIPCTION object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      cached_options_for_klient = options_for_klient
+      test_uuid = Kaui::Invoice.find_by_id(param_uuid, 'FULL', cached_options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.invoice_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in INVOICE object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      test_uuid = Kaui::Payment.find_by_external_key(param_uuid, false, true, options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.payment_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in PAYMENT object database.' }
+        render json: msg and return
+      end
+    end
+
+    begin
+      test_uuid = Kaui::InvoicePayment.find_by_id(param_uuid, false, true, options_for_klient)
+    rescue StandardError
+    ensure
+      if !test_uuid.blank? && (test_uuid.payment_id == param_uuid)
+        msg = { status: '200', message: 'UUID do exist in INVOICE PAYMENT object database.' }
+        render json: msg and return
+      end
+    end
+
+
+
+    msg = { status: '431', message: 'UUID do exist in  object database.' }
+    render json: msg and return
+
+  end
+
+
   def create
     @custom_field = Kaui::CustomField.new(params.require(:custom_field))
 
@@ -65,4 +152,5 @@ class Kaui::CustomFieldsController < Kaui::EngineController
 
     redirect_to custom_fields_path, :notice => 'Custom field was successfully created'
   end
+
 end

--- a/app/controllers/kaui/custom_fields_controller.rb
+++ b/app/controllers/kaui/custom_fields_controller.rb
@@ -127,7 +127,7 @@ class Kaui::CustomFieldsController < Kaui::EngineController
 
 
 
-    msg = { status: '431', message: 'UUID do exist in  object database.' }
+    msg = { status: '431', message: 'UUID do not  exist in  object database.' }
     render json: msg and return
 
   end

--- a/app/views/kaui/custom_fields/new.html.erb
+++ b/app/views/kaui/custom_fields/new.html.erb
@@ -1,3 +1,4 @@
+<%= include_gon(:camel_case => true) %>
 <div class="register">
   <div class="col-md-8 col-md-offset-2">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,8 +147,10 @@ Kaui::Engine.routes.draw do
 
   scope '/custom_fields' do
     match '/pagination' => 'custom_fields#pagination', :via => :get, :as => 'custom_fields_pagination'
+    match '/check_object_exist' => 'custom_fields#check_object_exist', :via => :get, :as => 'custom_fields_check_object_exist'
+
   end
-  resources :custom_fields, :only => [:index, :new, :create]
+  resources :custom_fields, :only => [:index, :new, :create, :check_object_exist]
 
   scope '/tenants' do
     match '/' => 'tenants#index', :via => :get, :as => 'tenants'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'kenui', '~> 2.0'
   s.add_dependency 'gon', '~> 6.4.0'
+  s.add_dependency 'docile', '~> 1.4.0'
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
+  s.add_dependency 'gon'
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon', '~> 6.2.1'
+  s.add_dependency 'gon', '~> 6.1.0'
 
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'multi_json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'simplecov', '>= 0.20.0'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'json', '>= 1.8.6'
   s.add_development_dependency 'listen'
   s.add_development_dependency 'puma'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'multi_json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov', '~> 0.21.2'
   s.add_development_dependency 'json', '>= 1.8.6'
   s.add_development_dependency 'listen'
   s.add_development_dependency 'puma'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'jbuilder'
   s.add_dependency 'gon'
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon', '~> v6.2.1'
+  s.add_dependency 'gon', '~> 6.2.1'
 
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon'
+  s.add_dependency 'gon', '~> 6.4.0'
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'multi_json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'simplecov', '~> 0.21.2'
+  s.add_development_dependency 'simplecov', '>= 0.20.0'
   s.add_development_dependency 'json', '>= 1.8.6'
   s.add_development_dependency 'listen'
   s.add_development_dependency 'puma'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon', '~> 6.4.0'
-  s.add_dependency 'docile', '~> 1.4.0'
+  s.add_dependency 'gon', '~> v6.2.1'
+
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
+  s.add_dependency 'jbuilder'
+  s.add_dependency 'gon'
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon', '~> 6.1.0'
+  s.add_dependency 'gon'
 
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'

--- a/kaui.gemspec
+++ b/kaui.gemspec
@@ -36,8 +36,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 2.2.3'
 
   s.add_dependency 'kenui', '~> 2.0'
-  s.add_dependency 'gon'
-
 
   s.add_dependency 'jquery-ui-rails', '~> 6.0'
   s.add_dependency 'sass-rails', '~> 5.0'

--- a/lib/kaui/engine.rb
+++ b/lib/kaui/engine.rb
@@ -23,6 +23,7 @@ require 'concurrent'
 require 'mustache-js-rails'
 require 'nokogiri'
 require 'time'
+require 'gon'
 
 module Kaui
   class Engine < ::Rails::Engine


### PR DESCRIPTION
This PR solves 1/2  of fallowing issue:
https://github.com/killbill/killbill-admin-ui/issues/291 

We do not have single end-point to call to check if object exist in data base, objects have variety of types (ACCOUNT, BUNDLE, INVOICE, etc).  

Our goal is to:
- validate if object is UUID before form is submitted
- validate if object exist in database

when we call our end-point /custom_fields/check_object_exist?uuid=e94367c4-d1db-43c9-b208-740b1c628eda

single example:
`{"status":"200","message":"UUID do exist in ACCOUNT object database."}`

or
`{"status":"431","message":"UUID do exist in  object database."}`



todo:
- JS part
- I18n
- Tests
- Invoice items (need invoice object to show items, need more debug)

This is open PR, draft.
