### PR TITLE
initializer: remove hack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,4 @@ end
 # gem 'killbill-client', '3.2.0'
 
 # gem 'kenui', :path => '../killbill-email-notifications-ui'
-# gem 'kenui', :git => 'https://github.com/killbill/killbill-email-notifications-ui.git', :branch => 'master'
-gem 'kenui', git: 'https://github.com/killbill/killbill-email-notifications-ui.git', branch: 'rails-upgrade'
+gem 'kenui', git: 'https://github.com/killbill/killbill-email-notifications-ui.git', branch: 'master'

--- a/lib/kaui/engine.rb
+++ b/lib/kaui/engine.rb
@@ -32,9 +32,14 @@ require 'popper_js'
 module Kaui
   class Engine < ::Rails::Engine
     isolate_namespace Kaui
+    config.autoload_once_paths = %W[
+      #{root}/app/controllers
+      #{root}/app/helpers
+      #{root}/app/models
+    ]
 
-    initializer 'kaui_engine.action_controller' do |_app|
-      ActiveSupport.on_load :action_controller do
+    initializer 'kaui_engine.action_controller', before: :load_config_initializers do |_app|
+      ActiveSupport.on_load :action_controller_base do
         helper Kaui::Engine.helpers
       end
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -33,6 +33,3 @@ module Dummy
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end
-
-# Hack - not sure why it's required
-Dir["#{File.dirname(__FILE__)}/../../../app/helpers/kaui/*.rb"].each { |file| require file }


### PR DESCRIPTION
Autoloading from initializers has been deprecated in Rails 7, see

  https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots