### PR TITLE
285 Update logic cancel by default policy and new test cases

### DIFF
--- a/app/controllers/kaui/subscriptions_controller.rb
+++ b/app/controllers/kaui/subscriptions_controller.rb
@@ -118,13 +118,14 @@ module Kaui
       # START_OF_TERM is *not* a valid entitlement_policy and so would default to IMMEDIATE
       entitlement_policy = billing_policy && billing_policy == 'START_OF_TERM' ? 'IMMEDIATE' : billing_policy
 
-      # true by default
-      use_requested_date_for_billing = (params[:use_requested_date_for_billing] || '1') == '1'
-
+      # true by default except default policy
+      use_requested_date_for_billing = if requested_date
+                                         (params[:use_requested_date_for_billing] || '1') == '1'
+                                       else
+                                         nil
+                                       end
       subscription = Kaui::Subscription.find_by_id(params.require(:id), options_for_klient)
-
       subscription.cancel(current_user.kb_username, params[:reason], params[:comment], requested_date, entitlement_policy, billing_policy, use_requested_date_for_billing, options_for_klient)
-
       redirect_to kaui_engine.account_bundles_path(subscription.account_id), notice: 'Subscription was successfully cancelled'
     end
 

--- a/app/views/kaui/subscriptions/_cancel_by_date_modal.html.erb
+++ b/app/views/kaui/subscriptions/_cancel_by_date_modal.html.erb
@@ -35,10 +35,7 @@
       <div class="modal-footer">
         <div class="alert alert-warning">
           <strong>Notice</strong>
-          <ul>
-            <li>When <span class="label label-default">Use requested date for billing?</span> is checked, then entitlement date and billing date are going to be equal to the requested date.</li>
-            <li>When <strong>not</strong> checked, then the entitlement date will be set with requested date, and billing date will default to now.</li>
-          </ul>
+          <%= raw t('views.subscriptions.requested_date_for_billing_notice') %>
         </div>
       </div>
     </div><!-- /.modal-content -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,3 +57,9 @@ en:
       invalid_xml: "Invalid XML: %{error}"
       invalid_min_date: "Invalid min date format"
       invalid_max_date: "Invalid max date format"
+  views:
+    subscriptions:
+      requested_date_for_billing_notice: <ul>
+        <li>When <span class="label label-default">Use requested date for billing?</span> is checked, then entitlement date and billing date are going to be equal to the requested date.</li>
+        <li>When <strong>not</strong> checked, then the entitlement date will be set with requested date, and billing date will be derived from the catalog policy.</li>
+        </ul>

--- a/test/fixtures/catalog-sample-for-cancel-subscription.xml
+++ b/test/fixtures/catalog-sample-for-cancel-subscription.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://docs.killbill.io/latest/catalog.xsd">
+  <effectiveDate>2019-01-02T00:00:00+00:00</effectiveDate>
+  <catalogName>SpyCarAdvanced</catalogName>
+  <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+  <currencies>
+    <currency>USD</currency>
+  </currencies>
+  <products>
+    <product name="Sports">
+      <category>BASE</category>
+    </product>
+  </products>
+  <rules>
+    <changePolicy>
+      <changePolicyCase>
+        <policy>END_OF_TERM</policy>
+      </changePolicyCase>
+    </changePolicy>
+    <cancelPolicy>
+      <cancelPolicyCase>
+        <policy>END_OF_TERM</policy>
+      </cancelPolicyCase>
+    </cancelPolicy>
+  </rules>
+  <plans>
+    <plan name="standard-monthly">
+      <product>Sports</product>
+      <initialPhases />
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>25</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+  </plans>
+  <priceLists>
+    <defaultPriceList name="DEFAULT">
+      <plans>
+        <plan>standard-monthly</plan>
+      </plans>
+    </defaultPriceList>
+  </priceLists>
+</catalog>

--- a/test/functional/kaui/functional_test_helper_nosetup.rb
+++ b/test/functional/kaui/functional_test_helper_nosetup.rb
@@ -13,10 +13,9 @@ module Kaui
     # Rails helpers
     #
 
-    def setup_functional_test(nb_configured_tenants, setup_tenant_key_secret)
+    def setup_functional_test(nb_configured_tenants, setup_tenant_key_secret, tenant_data = {})
       # Create useful data to exercise the code
-      created_tenant = setup_test_data(nb_configured_tenants, setup_tenant_key_secret)
-
+      created_tenant = setup_test_data(nb_configured_tenants, setup_tenant_key_secret, tenant_data)
       @routes                        = Kaui::Engine.routes
       @request.env['devise.mapping'] = Devise.mappings[:user]
 

--- a/test/killbill_test_helper.rb
+++ b/test/killbill_test_helper.rb
@@ -22,7 +22,8 @@ module Kaui
     # Kill Bill specific helpers
     #
 
-    def setup_test_data(nb_configured_tenants, setup_tenant_key_secret)
+    def setup_test_data(nb_configured_tenants, setup_tenant_key_secret, tenant_data = {})
+      @tenant_data = tenant_data
       @tenant            = setup_and_create_test_tenant(nb_configured_tenants)
       @account           = create_account(@tenant)
       @account2          = create_account(@tenant)
@@ -201,7 +202,7 @@ module Kaui
       tenant.api_secret = api_secret
 
       # Upload the default SpyCarAdvanced.xml catalog
-      catalog_xml = File.read('test/fixtures/SpyCarAdvanced.xml')
+      catalog_xml = File.read((@tenant_data && @tenant_data[:catalog_file]) || 'test/fixtures/SpyCarAdvanced.xml')
       Kaui::AdminTenant.upload_catalog(catalog_xml, user, reason, comment, build_options(tenant))
 
       tenant


### PR DESCRIPTION
The following ticket: https://github.com/killbill/killbill-admin-ui/issues/285
Update: 
+ use_requested_date_for_billing default to true except for the default policy cancel case. 
+ Added new test cases for all cancel scenarios
+ Update Use requested date for billing? notice, using I18n