### PR TITLE
232 Remove the limitation for plan display

### DIFF
--- a/app/models/kaui/catalog.rb
+++ b/app/models/kaui/catalog.rb
@@ -92,7 +92,7 @@ module Kaui
           end
         end.flatten!
 
-        selected = tmp.select { |p| p.phases.length.to_i <= 2 && p.phases[p.phases.length - 1].type == 'EVERGREEN' }
+        selected = tmp.select { |p| p.phases.length.to_i <= 2 }
 
         currencies = catalog.currencies
 
@@ -104,7 +104,7 @@ module Kaui
 
           # Embellish SimplePlanAttributes to contain a map currency -> amount (required in the view)
           class << simple_plan
-            attr_accessor :prices
+            attr_accessor :prices, :final_phase_duration
           end
           simple_plan.prices = plan.phases[-1].prices.each_with_object({}) do |e, r|
             r[e.currency] = e.value
@@ -118,6 +118,12 @@ module Kaui
           simple_plan.billing_period = plan.billing_period
           simple_plan.trial_length = has_trial ? plan.phases[0].duration.number : 0
           simple_plan.trial_time_unit = has_trial ? plan.phases[0].duration.unit : 'N/A'
+          last_phase_duration = plan.phases.last.duration
+          simple_plan.final_phase_duration = if last_phase_duration.number.positive?
+                                               "#{last_phase_duration.number} #{last_phase_duration.unit.downcase}"
+                                             else
+                                               last_phase_duration.unit
+                                             end
 
           result << simple_plan
         end

--- a/app/views/kaui/admin_tenants/_show_catalog_simple.erb
+++ b/app/views/kaui/admin_tenants/_show_catalog_simple.erb
@@ -30,12 +30,13 @@
 
     <thead>
     <tr>
-      <th>Plan Id</th>
-      <th>Product</th>
-      <th>Category</th>
-      <th>Billing Period</th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.plan_id') %></th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.product') %></th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.category') %></th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.billing_period') %></th>
       <th id="currency_select"></th>
-      <th>Trial</th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.trial') %></th>
+      <th><%= I18n.translate('views.catalogs.show.plan_table.final_phase_duration') %></th>
       <th></th>
     </tr>
     </thead>
@@ -72,6 +73,11 @@
             {{#trial_length}} {{trial_length}} {{#humanized_time_unit}}{{trial_time_unit}}{{/humanized_time_unit}} {{/trial_length}}
             {{^trial_length}} N/A {{/trial_length}}
           </td>
+
+          <td>
+            {{final_phase_duration}}
+          </td>
+
           <td><a class="btn btn-xs"
                  href="{{new_plan_currency_path}}"><i class="fa fa-plus-square"></i> currency</a></td>
         </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,12 @@ en:
         <li>When <span class="label label-default">Use requested date for billing?</span> is checked, then entitlement date and billing date are going to be equal to the requested date.</li>
         <li>When <strong>not</strong> checked, then the entitlement date will be set with requested date, and billing date will be derived from the catalog policy.</li>
         </ul>
+    catalogs:
+      show:
+        plan_table:
+          plan_id: "Plan Id"
+          product: "Product"
+          category: "Category"
+          billing_period: "Billing Period"
+          trial: "Trial"
+          final_phase_duration: "Final Phase Duration"


### PR DESCRIPTION
Here is the following ticket: https://github.com/killbill/killbill-admin-ui/issues/232
+ Basically, we removed the old limitation which only displays catalogs with the final phase EVERGREEN
+ Add a new column to display Final Phase Duration
+ Update I18n