### PR TITLE
Fix bug unable to show plugins icon

### DIFF
--- a/app/assets/config/kaui_manifest.js
+++ b/app/assets/config/kaui_manifest.js
@@ -23,6 +23,7 @@
 //= link bootstrap_and_overrides.scss
 //= link kaui/kaui.scss
 //= link kaui_application.css
+//= link application.js
 
 // Kanaui
 //= require js-routes

--- a/app/views/kaui/layouts/kaui_header.html.erb
+++ b/app/views/kaui/layouts/kaui_header.html.erb
@@ -5,7 +5,7 @@
 
   <title>Kaui</title>
   <%= stylesheet_link_tag 'kaui_application', :media => 'all' %>
-
+  <%= javascript_include_tag 'application' %>
 
   <%= csrf_meta_tags %>
 


### PR DESCRIPTION
The Plugins icon was unable to show after the Rails 7 upgrade.
I found that the killbill-admin-ui was unable to load the standalone.js which will help to show the plugins icon.
