### PR TITLE
Remove Kernel's define_singleton_method patch

### DIFF
--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -203,14 +203,3 @@ module Kaui
     }
   end
 end
-
-# ruby-1.8 compatibility
-module Kernel
-  # rubocop:disable Style/ArgumentsForwarding
-  def define_singleton_method(*args, &)
-    class << self
-      self
-    end.send(:define_method, *args, &)
-  end
-  # rubocop:enable Style/ArgumentsForwarding
-end


### PR DESCRIPTION
* This PR addresses [this comment](https://github.com/killbill/killbill-admin-ui/pull/371#issuecomment-1658046380).
* The patch was added in commit 23e8e181 back in 2012 to support [define_singleton_method](https://ruby-doc.org/3.2.2/Object.html#method-i-define_singleton_method) for Ruby 1.8.
* Since [Ruby 1.8's EOL was in 2014](https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/), and KAUI [requires Ruby 3.2.2+](https://github.com/killbill/killbill-admin-ui/blob/ae2e8ace5c322476ade17fd4aba0f9d3fb462d5a/README.md?plain=1#L22), it should be safe to remove the patch.
* I made sure all tests pass after the removal.
   * `define_singleton_method` is only used in [TagDefinition](https://github.com/killbill/killbill-admin-ui/blob/ae2e8ace5c322476ade17fd4aba0f9d3fb462d5a/app/models/kaui/tag_definition.rb#L27-L29) to define `TagDefinition.all_for_*` methods.
   * The defined methods are used in places like [`account_tags#edit`](https://github.com/killbill/killbill-admin-ui/blob/ae2e8ace5c322476ade17fd4aba0f9d3fb462d5a/app/controllers/kaui/account_tags_controller.rb#L30) which have [tests](https://github.com/killbill/killbill-admin-ui/blob/ae2e8ace5c322476ade17fd4aba0f9d3fb462d5a/test/functional/kaui/account_tags_controller_test.rb#L13-L19).