### PR TITLE
Update copy to clipboard function

### DIFF
--- a/app/assets/javascripts/kaui/kaui.js
+++ b/app/assets/javascripts/kaui/kaui.js
@@ -386,7 +386,6 @@ function setObjectIdPopover(){
             content: function() {
                 var template = '<div class="{{id}}-content" >' +
                     '{{id}}&emsp;<i id="{{id}}-copy" class="fa fa-clipboard copy-icon" aria-hidden="true"></i> ' +
-                    '<input id="{{id}}-placeholder" class="form-control hidden"> ' +
                     '</div>';
 
                 var popover_html = Mustache.render( template , { id: $(this).data("id") });
@@ -415,14 +414,7 @@ function setObjectIdPopover(){
             copyIdImg.data("popover",$(this).attr("id"));
             copyIdImg.click(function(e){
                 var id = ($(this).attr("id")).replace('-copy','');
-                var placeholder = $("#" + objectId + "-placeholder");
-                var popover = $("#" + copyIdImg.data("popover"));
-                placeholder.val(id);
-                placeholder.removeClass("hidden");
-                placeholder.select();
-
-                document.execCommand("Copy");
-                placeholder.addClass("hidden");
+                navigator.clipboard.writeText(id);
                 ajaxInfoAlert("Id [" + id + "] was copied into the clipboard!", 4000);
 
                 if (!isBlank(popover)) {


### PR DESCRIPTION
Here is the following ticket: https://github.com/killbill/killbill-admin-ui/issues/348
- Follow the Bootstrap document here: https://getbootstrap.com/docs/3.4/javascript/#popovers-usage
You can see the option sanitize, the default value is true, which means it will sanitize the content option.
The content option included an input tag, which is not in this whiteList https://getbootstrap.com/docs/3.4/javascript/#js-sanitizer
So the popover will remove the input tag, which is used for the Copy to clipboard trick: https://github.com/killbill/killbill-admin-ui/blob/985e5c94c893abe780cc9361e9dbe9f568afd3b1/app/assets/javascripts/kaui/kaui.js#L386
That’s why we are unable to copy the text.

- We use the execCommand function to execute the copy to the clipboard, which is deprecated: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
