### PR TITLE
Eng 22484 ability to select multiple line items in a single click during refund

### DIFF
--- a/app/views/kaui/refunds/_form.html.erb
+++ b/app/views/kaui/refunds/_form.html.erb
@@ -189,12 +189,13 @@
         var isChecked = $('#selectAll').prop('checked');
         $('input').filter(function() { return this.id.match(/tf_adj_/) }).each(function() {
             var textFieldId = this.id;
+            var textFieldIdElm = $("#" + textFieldId);
             var checkboxId = textToCheckboxId(this.id);
             if(checkboxId){
                 $("#" + checkboxId).prop('checked', isChecked);
-                $("#" + textFieldId).prop('readonly', isChecked);
+                textFieldIdElm.prop('readonly', isChecked);
                 if(!isChecked){
-                    $("#" + textFieldId).attr('value', $("#" + textFieldId).attr('originalValue'));
+                    textFieldIdElm.attr('value', textFieldIdElm.attr('originalValue'));
                 }
                 validateInvoiceItemAmount(textFieldId);
             }

--- a/app/views/kaui/refunds/_form.html.erb
+++ b/app/views/kaui/refunds/_form.html.erb
@@ -152,7 +152,7 @@
         validateRefundAmount();
     };
     /*
-     * Check status of all items check-box check/uncheck status for selct all chec-kbox 
+     * Check status of all items check-box check/uncheck status for select all chec-kbox 
      */
     var checkSelectAllCheckboxStatus = function(){
         var checkedCheckBoxCount = 0;
@@ -183,7 +183,7 @@
     };
 
     /*
-    * When clicking selct all checkbox - select each items, disable amount and recompute total refund amount
+    * When clicking select all checkbox - select each items, disable amount and recompute total refund amount
     */
     var onClickInvoiceItemsSelectAll = function(event){
         var isChecked = false;

--- a/app/views/kaui/refunds/_form.html.erb
+++ b/app/views/kaui/refunds/_form.html.erb
@@ -26,7 +26,7 @@
         <div class="form-group">
             <label class="col-sm-2 control-label"></label>
             <div class="col-sm-10">
-                <input type="checkbox" id="selectall">
+                <input type="checkbox" id="selectAll">
                 <%="Select All" %>
             </div>
         </div>
@@ -163,11 +163,11 @@
                 checkedCheckBoxCount++;
             }
         });
-        $("#selectall").prop('checked', checkedCheckBoxCount == checkboxListCount);
+        $("#selectAll").prop('checked', checkedCheckBoxCount == checkboxListCount);
     }
 
     /*
-    * When clicking checkbox for each item, disable amount, check select all status and recompute total refund amount
+    * When clicking checkbox for each item, disable amount, Changes SelectAll status and recompute total refund amount
     */
     var onClickInvoiceItemAdjustment = function(event) {
         var id = checkboxToTextId(this.id);
@@ -186,14 +186,11 @@
     * When clicking select all checkbox - select each items, disable amount and recompute total refund amount
     */
     var onClickInvoiceItemsSelectAll = function(event){
-        var isChecked = false;
-        if ($(this).is(':checked')) {
-            isChecked = true;
-        }
+        var isChecked = $('#selectAll').prop('checked');
         $('input').filter(function() { return this.id.match(/tf_adj_/) }).each(function() {
             var textFieldId = this.id;
             var checkboxId = textToCheckboxId(this.id);
-            if(checkboxId && textFieldId){
+            if(checkboxId){
                 $("#" + checkboxId).prop('checked', isChecked);
                 $("#" + textFieldId).prop('readonly', isChecked);
                 if(!isChecked){
@@ -261,9 +258,7 @@
         /*
         * Attach handler onClickInvoiceItemsSelectAll for selectall checkbox
         */
-        $('input').filter(function() {
-            return this.id.match(/selectall/);
-        }).click(onClickInvoiceItemsSelectAll);
+        $('#selectAll').click(onClickInvoiceItemsSelectAll);
 
         /*
         * Attach handler for all invoice item text areas so that:

--- a/app/views/kaui/refunds/_form.html.erb
+++ b/app/views/kaui/refunds/_form.html.erb
@@ -23,6 +23,13 @@
     </div>
 
     <div id="invoiceItems" style="display:none">
+        <div class="form-group">
+            <label class="col-sm-2 control-label"></label>
+            <div class="col-sm-10">
+                <input type="checkbox" id="selectall">
+                <%="Select All" %>
+            </div>
+        </div>
       <% @invoice.items.each_with_index do |ii, index| %>
           <% if ii.amount > 0 %>
               <div id=<%= "div_#{ii.invoice_item_id}" %> class="form-group">
@@ -144,9 +151,23 @@
         }
         validateRefundAmount();
     };
+    /*
+     * Check status of all items check-box check/uncheck status for selct all chec-kbox 
+     */
+    var checkSelectAllCheckboxStatus = function(){
+        var checkedCheckBoxCount = 0;
+        var checkboxList = $('input').filter(function() { return this.id.match(/cb_adj_/) });
+        var checkboxListCount = checkboxList.length;
+        checkboxList.each(function() {
+            if ($(this).is(':checked')) {
+                checkedCheckBoxCount++;
+            }
+        });
+        $("#selectall").prop('checked', checkedCheckBoxCount == checkboxListCount);
+    }
 
     /*
-    * When clicking checkbox for each item, disable amount and recompute total refund amount
+    * When clicking checkbox for each item, disable amount, check select all status and recompute total refund amount
     */
     var onClickInvoiceItemAdjustment = function(event) {
         var id = checkboxToTextId(this.id);
@@ -158,7 +179,31 @@
         }
         recomputeRefundAmountAndValidateAmount();
         validateInvoiceItemAmount(id);
+        checkSelectAllCheckboxStatus();
     };
+
+    /*
+    * When clicking selct all checkbox - select each items, disable amount and recompute total refund amount
+    */
+    var onClickInvoiceItemsSelectAll = function(event){
+        var isChecked = false;
+        if ($(this).is(':checked')) {
+            isChecked = true;
+        }
+        $('input').filter(function() { return this.id.match(/tf_adj_/) }).each(function() {
+            var textFieldId = this.id;
+            var checkboxId = textToCheckboxId(this.id);
+            if(checkboxId && textFieldId){
+                $("#" + checkboxId).prop('checked', isChecked);
+                $("#" + textFieldId).prop('readonly', isChecked);
+                if(!isChecked){
+                    $("#" + textFieldId).attr('value', $("#" + textFieldId).attr('originalValue'));
+                }
+                validateInvoiceItemAmount(textFieldId);
+            }
+        });
+        recomputeRefundAmountAndValidateAmount();
+    }
 
     /*
     * When selecting Invoice Adjustment or No Adjustment, hide invoice items and recompute refund Amount
@@ -212,6 +257,13 @@
         $('input').filter(function() {
             return this.id.match(/cb_adj_/);
         }).click(onClickInvoiceItemAdjustment);
+
+        /*
+        * Attach handler onClickInvoiceItemsSelectAll for selectall checkbox
+        */
+        $('input').filter(function() {
+            return this.id.match(/selectall/);
+        }).click(onClickInvoiceItemsSelectAll);
 
         /*
         * Attach handler for all invoice item text areas so that:


### PR DESCRIPTION
Fix #368 

-   Adds two methods `onClickInvoiceItemsSelectAll` and `checkSelectAllCheckboxStatus` to handle click events on selecting the checkbox.
- `onClickInvoiceItemsSelectAll` - will trigger when the select-all is checked and unchecked
- `checkSelectAllCheckboxStatus` - will trigger when line items are checked and unchecked
- New UI - [Demo](https://github.com/killbill/killbill-admin-ui/assets/138654702/108bc6b2-c208-4d02-8b5c-b597d3f8ccde)
<img width="773" alt="Screenshot 2023-09-04 at 5 42 34 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/3f678647-e902-41de-b7cf-347cd6835e52">
- Old UI:
<img width="773" alt="Screenshot 2023-09-04 at 7 59 17 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/5f0ef50d-2e66-4b4a-924f-85b7965b4373">

- Solution discussion doc 
[killbill-admin-ui_issues_368.pdf](https://github.com/killbill/killbill-admin-ui/files/12514634/killbill-admin-ui_issues_368.pdf)

