### PR TITLE
Control tags are not appearing in account information section #376

### DIFF
--- a/app/models/kaui/tag_definition.rb
+++ b/app/models/kaui/tag_definition.rb
@@ -25,7 +25,7 @@ module Kaui
 
     ALL_OBJECT_TYPES.each do |object_type|
       define_singleton_method "all_for_#{object_type.downcase}" do |options_for_klient|
-        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include?(object_type) || tag_definition.is_control_tag }).sort
+        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include? object_type || tag_definition.is_control_tag }).sort
       end
     end
 

--- a/app/models/kaui/tag_definition.rb
+++ b/app/models/kaui/tag_definition.rb
@@ -25,7 +25,7 @@ module Kaui
 
     ALL_OBJECT_TYPES.each do |object_type|
       define_singleton_method "all_for_#{object_type.downcase}" do |options_for_klient|
-        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include?(object_type || tag_definition.is_control_tag) }).sort
+        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include?(object_type) }).sort
       end
     end
 

--- a/app/models/kaui/tag_definition.rb
+++ b/app/models/kaui/tag_definition.rb
@@ -25,7 +25,7 @@ module Kaui
 
     ALL_OBJECT_TYPES.each do |object_type|
       define_singleton_method "all_for_#{object_type.downcase}" do |options_for_klient|
-        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include? object_type || tag_definition.is_control_tag }).sort
+        (all('NONE', options_for_klient).delete_if { |tag_definition| !tag_definition.applicable_object_types.include?(object_type || tag_definition.is_control_tag) }).sort
       end
     end
 

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -52,9 +52,8 @@ module Kaui
     test 'invoice related tags list should have WRITTEN_OFF tag' do
       options_for_klient = build_options_for_klient
       invoice_tags = Kaui::TagDefinition.all_for_invoice(options_for_klient)
-      invoice_tags.each do |invoice_tag|
-        assert_equal 'WRITTEN_OFF', invoice_tag.name
-      end
+      assert_equal 1, invoice_tags.count
+      assert_equal 'WRITTEN_OFF', invoice_tags[0].name
     end
 
     def build_options_for_klient

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -4,11 +4,21 @@ require 'test_helper'
 
 module Kaui
   class TagDefinitionTest < ActiveSupport::TestCase
+    include Kaui::KillbillTestHelper
+
     test 'can detect system tags' do
       1.upto(9).each do |i|
         assert Kaui::TagDefinition.new(id: "00000000-0000-0000-0000-00000000000#{i}").system_tag?
       end
       assert !Kaui::TagDefinition.new(id: SecureRandom.uuid).system_tag?
+    end
+
+    test 'can list all tags user and control' do
+      tenant = create_tenant
+      assert_not_nil(tenant)
+      options_for_klient = build_options(tenant)
+      tags = Kaui::TagDefinition.all_for_account(options_for_klient)
+      assert_equal 9, tags.count
     end
   end
 end

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -13,12 +13,53 @@ module Kaui
       assert !Kaui::TagDefinition.new(id: SecureRandom.uuid).system_tag?
     end
 
-    test 'can list all user and control tags' do
-      tenant = create_tenant
+    test 'can create awesome_customer tag and should return it for object_types=[ACCOUNT] tags ' do
+      random_id = SecureRandom.uuid;
+      options_for_klient = get_options_for_klient
+      
+      tag_definition = Kaui::TagDefinition.new({ 
+        id: random_id,
+        is_control_tag: false,
+        name: 'awesome_customer',
+        description: 'A user-defined tag',
+        applicable_object_types: ['ACCOUNT'] })
+      tag_definition.create('kaui search test', nil, nil, options_for_klient) #creates 'awesome_customer tag definition for object_types=[ACCOUNT]
+
+      tags = Kaui::TagDefinition.all_for_account(options_for_klient) #gets all tag definition list for object_types=[ACCOUNT]
+
+      tags.each do |tag|
+        next unless tag.id == random_id
+        assert 'awesome_customer', tag.name #checks 'awesome_customer tag is available in the list or not
+      end
+    end  
+
+    test 'can list all account users and control tags' do
+      options_for_klient = get_options_for_klient
+      account_tags = Kaui::TagDefinition.all_for_account(options_for_klient)
+      assert_equal 9, account_tags.count
+    end
+
+    test 'account tags list should not have WRITTEN_OFF tag' do
+      options_for_klient = get_options_for_klient
+      account_tags = Kaui::TagDefinition.all_for_account(options_for_klient)
+      account_tags.each do |account_tag|
+        assert_not_equal 'WRITTEN_OFF', account_tag.name
+      end
+    end
+
+    test 'invoice related tags list should have WRITTEN_OFF tag' do
+      options_for_klient = get_options_for_klient
+      invoice_tags = Kaui::TagDefinition.all_for_invoice(options_for_klient)
+      invoice_tags.each do |invoice_tag|
+        assert_equal 'WRITTEN_OFF', invoice_tag.name
+      end
+    end
+
+    def get_options_for_klient
+      tenant = create_tenant #create a tenant for authorization
       assert_not_nil(tenant)
-      options_for_klient = build_options(tenant)
-      tags = Kaui::TagDefinition.all_for_account(options_for_klient)
-      assert_equal 9, tags.count
+      options_for_klient = build_options(tenant) #get options object which contains tenant's secret, apikey, username and password
+      options_for_klient
     end
   end
 end

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -13,7 +13,7 @@ module Kaui
       assert !Kaui::TagDefinition.new(id: SecureRandom.uuid).system_tag?
     end
 
-    test 'can list all tags user and control' do
+    test 'can list all user and control tags' do
       tenant = create_tenant
       assert_not_nil(tenant)
       options_for_klient = build_options(tenant)

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -14,24 +14,20 @@ module Kaui
     end
 
     test 'can create awesome_customer tag and should return it for object_types=[ACCOUNT] tags ' do
-      random_id = SecureRandom.uuid
       options_for_klient = build_options_for_klient
-
       tag_definition = Kaui::TagDefinition.new({
-                                                 id: random_id,
                                                  is_control_tag: false,
                                                  name: 'awesome_customer',
                                                  description: 'A user-defined tag',
                                                  applicable_object_types: ['ACCOUNT']
                                                })
-      tag_definition.create('kaui search test', nil, nil, options_for_klient) # creates 'awesome_customer tag definition for object_types=[ACCOUNT]
-
+      tag_definition = tag_definition.create('kaui search test', nil, nil, options_for_klient) # creates 'awesome_customer tag definition for object_types=[ACCOUNT]
       tags = Kaui::TagDefinition.all_for_account(options_for_klient) # gets all tag definition list for object_types=[ACCOUNT]
 
       tags.each do |tag|
-        next unless tag.id == random_id
+        next unless tag.id == tag_definition.id
 
-        assert 'awesome_customer', tag.name # checks 'awesome_customer tag is available in the list or not
+        assert_equal 'awesome_customer', tag.name # checks 'awesome_customer tag is available in the list or not
       end
     end
 

--- a/test/unit/kaui/tag_definition_test.rb
+++ b/test/unit/kaui/tag_definition_test.rb
@@ -14,33 +14,35 @@ module Kaui
     end
 
     test 'can create awesome_customer tag and should return it for object_types=[ACCOUNT] tags ' do
-      random_id = SecureRandom.uuid;
-      options_for_klient = get_options_for_klient
-      
-      tag_definition = Kaui::TagDefinition.new({ 
-        id: random_id,
-        is_control_tag: false,
-        name: 'awesome_customer',
-        description: 'A user-defined tag',
-        applicable_object_types: ['ACCOUNT'] })
-      tag_definition.create('kaui search test', nil, nil, options_for_klient) #creates 'awesome_customer tag definition for object_types=[ACCOUNT]
+      random_id = SecureRandom.uuid
+      options_for_klient = build_options_for_klient
 
-      tags = Kaui::TagDefinition.all_for_account(options_for_klient) #gets all tag definition list for object_types=[ACCOUNT]
+      tag_definition = Kaui::TagDefinition.new({
+                                                 id: random_id,
+                                                 is_control_tag: false,
+                                                 name: 'awesome_customer',
+                                                 description: 'A user-defined tag',
+                                                 applicable_object_types: ['ACCOUNT']
+                                               })
+      tag_definition.create('kaui search test', nil, nil, options_for_klient) # creates 'awesome_customer tag definition for object_types=[ACCOUNT]
+
+      tags = Kaui::TagDefinition.all_for_account(options_for_klient) # gets all tag definition list for object_types=[ACCOUNT]
 
       tags.each do |tag|
         next unless tag.id == random_id
-        assert 'awesome_customer', tag.name #checks 'awesome_customer tag is available in the list or not
+
+        assert 'awesome_customer', tag.name # checks 'awesome_customer tag is available in the list or not
       end
-    end  
+    end
 
     test 'can list all account users and control tags' do
-      options_for_klient = get_options_for_klient
+      options_for_klient = build_options_for_klient
       account_tags = Kaui::TagDefinition.all_for_account(options_for_klient)
       assert_equal 9, account_tags.count
     end
 
     test 'account tags list should not have WRITTEN_OFF tag' do
-      options_for_klient = get_options_for_klient
+      options_for_klient = build_options_for_klient
       account_tags = Kaui::TagDefinition.all_for_account(options_for_klient)
       account_tags.each do |account_tag|
         assert_not_equal 'WRITTEN_OFF', account_tag.name
@@ -48,18 +50,17 @@ module Kaui
     end
 
     test 'invoice related tags list should have WRITTEN_OFF tag' do
-      options_for_klient = get_options_for_klient
+      options_for_klient = build_options_for_klient
       invoice_tags = Kaui::TagDefinition.all_for_invoice(options_for_klient)
       invoice_tags.each do |invoice_tag|
         assert_equal 'WRITTEN_OFF', invoice_tag.name
       end
     end
 
-    def get_options_for_klient
-      tenant = create_tenant #create a tenant for authorization
+    def build_options_for_klient
+      tenant = create_tenant # create a tenant for authorization
       assert_not_nil(tenant)
-      options_for_klient = build_options(tenant) #get options object which contains tenant's secret, apikey, username and password
-      options_for_klient
+      build_options(tenant) # get options object which contains tenant's secret, apikey, username and password
     end
   end
 end


### PR DESCRIPTION
Issue no #376 

Before this fix, only users' tags were showing

<img width="1279" alt="Screenshot 2023-09-14 at 1 07 34 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/26df86e8-b9a0-481c-8e85-66b55173c1b3">

After this fix, both control and users' tags are showing

<img width="1246" alt="Screenshot 2023-09-14 at 10 55 48 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/b6f5bfbc-7cf6-4d47-9998-601903a36cd8">




[Demo](https://github.com/killbill/killbill-admin-ui/assets/138654702/96b332ab-3c2e-4d39-a094-ee0e8be16056)



