### PR TITLE
Customize invoice list column to show Organization/Account Name

### DIFF
--- a/app/controllers/kaui/invoices_controller.rb
+++ b/app/controllers/kaui/invoices_controller.rb
@@ -39,7 +39,7 @@ module Kaui
         end
         formatter = lambda do |invoice|
           row = [view_context.link_to(invoice.invoice_number, view_context.url_for(controller: :invoices, action: :show, account_id: invoice.account_id, id: invoice.invoice_id))]
-          row += Kaui.invoice_search_columns.call(invoice, view_context)[1]
+          row += Kaui.invoice_search_columns.call(invoice, view_context, invoice_search_columns)[1]
           row
         end
       else

--- a/app/controllers/kaui/invoices_controller.rb
+++ b/app/controllers/kaui/invoices_controller.rb
@@ -39,7 +39,7 @@ module Kaui
         end
         formatter = lambda do |invoice|
           row = [view_context.link_to(invoice.invoice_number, view_context.url_for(controller: :invoices, action: :show, account_id: invoice.account_id, id: invoice.invoice_id))]
-          row += Kaui.invoice_search_columns.call(invoice, view_context, invoice_search_columns)[1]
+          row += Kaui.invoice_search_columns.call(invoice, view_context, cached_options_for_klient)[1]
           row
         end
       else

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -68,7 +68,7 @@ module Kaui
     ]
   end
 
-  self.invoice_search_columns = lambda do |invoice = nil, view_context = nil|
+  self.invoice_search_columns = lambda do |invoice = nil, view_context = nil, cached_options_for_klient = nil|
     default_label = 'label-info'
     default_label = 'label-default' if invoice&.status == 'DRAFT'
     default_label = 'label-success' if invoice&.status == 'COMMITTED'

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -68,7 +68,7 @@ module Kaui
     ]
   end
 
-  self.invoice_search_columns = lambda do |invoice = nil, view_context = nil, cached_options_for_klient = nil|
+  self.invoice_search_columns = lambda do |invoice = nil, view_context = nil, _cached_options_for_klient = nil|
     default_label = 'label-info'
     default_label = 'label-default' if invoice&.status == 'DRAFT'
     default_label = 'label-success' if invoice&.status == 'COMMITTED'


### PR DESCRIPTION
[#381](https://github.com/killbill/killbill-admin-ui/issues/381)

**Problem to be solved:** As we can see in the screenshot, the invoices table only shows the invoice number but no details about which organization/account this invoice belongs to unless a user clicks on the invoice number and lands on the account invoice page.

<img width="1265" alt="Screenshot 2023-09-28 at 7 54 10 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/b8abedce-2511-4325-b475-38a0c0e3fd06">

**Solution:** As this is not an issue for all to resolve but is good to have, we are working on showing the organization name via the customization approach. In this approach, we are calling KILLBILL API which needs the `cached_options_for_klient` for authentication. So we are passing `cached_options_for_klient` to `Kaui.invoice_search_columns` as an optional parameter. This may be used for future improvement if others also need to make similar changes.

End Result: <img width="1173" alt="Screenshot 2023-09-28 at 8 03 29 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/287e0b11-acc3-476a-a57e-402b875a9513">