### PR TITLE
Issue 120 Fix bug cannot create Tag Definitions

### DIFF
--- a/app/views/kaui/tag_definitions/_form.html.erb
+++ b/app/views/kaui/tag_definitions/_form.html.erb
@@ -10,8 +10,7 @@
       <div class="col-sm-10" id="object_types">
         <% (@tag_definition.applicable_object_types || [:account]).each_with_index do |object_type, index| %>
         <div id="object_type_line_<%= index %>">
-          <%= f.select "applicable_object_types[#{index}]", object_types,
-                       {:selected => object_type, :id => "object_type_#{index}"}, :class => 'form-control tag-definition-select' %>
+        <%= select_tag "tag_definition[applicable_object_types][#{index}]", options_for_select(object_types),  {:selected => object_type, :id => "object_type_#{index}", :class => 'form-control tag-definition-select'} %>
           <a class='btn btn-xs' href="javascript:void(0);" onclick="delete_object_type(this);" id="delete_object_type_<%= index %>" <%= "style='display: none;'".html_safe if index == 0 %>>
             <%= '<i class="fa fa-times"></i>'.html_safe %>
           </a>


### PR DESCRIPTION
The issue raised here: https://github.com/rack/rack/issues/2128
I found that the issue comes from the rack gem, the parse_nested_query function.
The Gemfile from killbill-admin-ui: `gem 'rails', '~> 7.0.1'` -> `rails 7.0.8` -> will install rack 2.2.8
The Gemfile from killbill-admin-ui-standalone: `gem 'rails', '~> 7.0.0'` -> `rails 7.1.2` -> will install rack 3.0.8
You can compare the parse_nested_queryhere:
+ 3.0.8:https://github.com/rack/rack/blob/3-0-stable/lib/rack/query_parser.rb
+ 2.2.8:https://github.com/rack/rack/blob/2-2-stable/lib/rack/query_parser.rb

Here is our raw source data for POST:
```
authenticity_token=1cC60RSAumGOde_9icOPLNwLOUroWsWAb7mmqI6S6McpehjcvoKr8p57qivQd_F3DyHjrcGyksSXaq2EWrPEhg&t
ag_definition%5Bid%5D=&tag_definition%5Bapplicable_object_types%5B0%5D%5D=SUBSCRIPTION&tag_definition%5Bname%5D=test1&tag_definition%5Bdescription%5D=te
st1&commit=Save
```
And the result when using Rack::Utils.parse_nested_query:
+ 3.0.8:
```
{"authenticity_token"=>"1cC60RSAumGOde_9icOPLNwLOUroWsWAb7mmqI6S6McpehjcvoKr8p57qivQd_F3DyHjrcGyksSXaq2EWrPEhg",
 "tag_definition"=>{"id"=>"", "applicable_object_types[0"=>{"]"=>"SUBSCRIPTION"}, "name"=>"test1", "description"=>"test1"},
 "commit"=>"Save"}
```
+ 2.2.8:
```
{"authenticity_token"=>"1cC60RSAumGOde_9icOPLNwLOUroWsWAb7mmqI6S6McpehjcvoKr8p57qivQd_F3DyHjrcGyksSXaq2EWrPEhg",
 "t\nag_definition"=>{"id"=>""},
 "tag_definition"=>{"applicable_object_types"=>{"0"=>"SUBSCRIPTION"}, "name"=>"test1", "description"=>"te\nst1"},
 "commit"=>"Save"}
```

Rack 3.0 no longer supports parsing nested params like a[b[c]], the correct nested params should be a[b][c].
