### PR TITLE
New link on invoice page

### DIFF
--- a/app/views/kaui/invoices/show.html.erb
+++ b/app/views/kaui/invoices/show.html.erb
@@ -6,7 +6,7 @@
       Invoice <%= @invoice.invoice_number %>
       <% if !@invoice.invoice_number.blank? %>
         <%= Kaui.customer_invoice_link.call(@invoice, self) %>
-        <%= Kaui.customer_bulk_invoice_adjust_link.call(@invoice, self) %>
+        <%= Kaui.additional_invoice_links.call(@invoice, self) %>
       <% end %>
     </h1>
 

--- a/app/views/kaui/invoices/show.html.erb
+++ b/app/views/kaui/invoices/show.html.erb
@@ -4,10 +4,8 @@
 
     <h1>
       Invoice <%= @invoice.invoice_number %>
-      <% unless @invoice.invoice_number.blank? %>
+      <% if !@invoice.invoice_number.blank? %>
         <%= Kaui.customer_invoice_link.call(@invoice, self) %>
-      <% end %>
-      <% unless @invoice.invoice_number.blank? %>
         <%= Kaui.customer_bulk_invoice_adjust_link.call(@invoice, self) %>
       <% end %>
     </h1>

--- a/app/views/kaui/invoices/show.html.erb
+++ b/app/views/kaui/invoices/show.html.erb
@@ -7,6 +7,9 @@
       <% unless @invoice.invoice_number.blank? %>
         <%= Kaui.customer_invoice_link.call(@invoice, self) %>
       <% end %>
+      <% unless @invoice.invoice_number.blank? %>
+        <%= Kaui.customer_bulk_invoice_adjust_link.call(@invoice, self) %>
+      <% end %>
     </h1>
 
     <% dry_run = @invoice.invoice_number.blank? %>

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -48,7 +48,7 @@ module Kaui
 
   mattr_accessor :disable_sign_up_link
   mattr_accessor :additional_headers_partial
-  mattr_accessor :customer_bulk_invoice_adjust_link
+  mattr_accessor :additional_invoice_links
 
   self.home_path = -> { Kaui::Engine.routes.url_helpers.home_path }
   self.tenant_home_path = -> { Kaui::Engine.routes.url_helpers.tenants_path }
@@ -105,7 +105,7 @@ module Kaui
 
   self.customer_invoice_link = ->(invoice, ctx) { ctx.link_to 'View customer invoice html', ctx.kaui_engine.show_html_invoice_path(invoice.invoice_id), class: 'btn', target: '_blank' }
 
-  self.customer_bulk_invoice_adjust_link = ->(invoice, ctx) {}
+  self.additional_invoice_links = ->(invoice, ctx) {}
 
   self.demo_mode = false
 

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -105,7 +105,7 @@ module Kaui
 
   self.customer_invoice_link = ->(invoice, ctx) { ctx.link_to 'View customer invoice html', ctx.kaui_engine.show_html_invoice_path(invoice.invoice_id), class: 'btn', target: '_blank' }
 
-  self.customer_bulk_invoice_adjust_link = ->(invoice, ctx) {  }
+  self.customer_bulk_invoice_adjust_link = ->(invoice, ctx) {}
 
   self.demo_mode = false
 

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -48,6 +48,7 @@ module Kaui
 
   mattr_accessor :disable_sign_up_link
   mattr_accessor :additional_headers_partial
+  mattr_accessor :customer_bulk_invoice_adjust_link
 
   self.home_path = -> { Kaui::Engine.routes.url_helpers.home_path }
   self.tenant_home_path = -> { Kaui::Engine.routes.url_helpers.tenants_path }
@@ -103,6 +104,8 @@ module Kaui
   }
 
   self.customer_invoice_link = ->(invoice, ctx) { ctx.link_to 'View customer invoice html', ctx.kaui_engine.show_html_invoice_path(invoice.invoice_id), class: 'btn', target: '_blank' }
+
+  self.customer_bulk_invoice_adjust_link = ->(invoice, ctx) {  }
 
   self.demo_mode = false
 


### PR DESCRIPTION
[#369](https://github.com/killbill/killbill-admin-ui/issues/369)

Adds a new link on invoice page via customization approach to redirect to a new screen. the new screen is not available on open-source. 

Customize app with a new link as below
<img width="1230" alt="Screenshot 2023-12-08 at 4 55 01 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/460e5ef8-d97e-4338-b111-99b9aedfc65f">

Open-source no visible change as below 
<img width="1236" alt="Screenshot 2023-12-08 at 5 03 16 PM" src="https://github.com/killbill/killbill-admin-ui/assets/138654702/62534909-3214-401f-81c8-ed37dc3d92c8">
