### PR TITLE
Change CI file to fix the error Unable to start stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Start stack
         run: |
           cd docker
-          docker-compose -p it -f ${{ matrix.docker-compose-file }} up --no-start
-          docker start it_db_1
+          docker compose -p it -f ${{ matrix.docker-compose-file }} up --no-start
+          docker start it-db-1
       - name: Wait for MySQL
         if: ${{ matrix.docker-compose-file == 'docker-compose.ci.mysql.yml' }}
         run: |
@@ -87,7 +87,7 @@ jobs:
         # Sometimes it gets stuck (if Kill Bill starts when the DB isn't ready?)
         timeout-minutes: 4
         run: |
-          docker start it_killbill_1
+          docker start it-killbill-1
           count=0
           until $(curl --connect-timeout 10 --max-time 30 --output /dev/null --silent --fail http://${KB_ADDRESS}:${KB_PORT}/1.0/healthcheck); do
             if [[ "$count" == "180" ]]; then
@@ -128,10 +128,10 @@ jobs:
           echo "[DEBUG] docker ps -a"
           docker ps -a
           echo "[DEBUG] killbill env"
-          docker exec it_killbill_1 env || true
+          docker exec it-killbill-1 env || true
           echo "[DEBUG] db env"
-          docker exec it_db_1 env || true
+          docker exec it-db-1 env || true
           echo "[DEBUG] killbill logs"
-          docker logs -t --details it_killbill_1 || true
+          docker logs -t --details it-killbill-1 || true
           echo "[DEBUG] db logs"
-          docker logs -t --details it_db_1 || true
+          docker logs -t --details it-db-1 || true


### PR DESCRIPTION
Issue when running CI: 
`Run cd docker
  cd docker
  docker-compose -p it -f docker-compose.ci.postgresql.yml up --no-start
  docker start it_db_1
  shell: /usr/bin/bash -e {0}
  env:
    COMPOSE_DOCKER_CLI_BUILD: 1
    DB_NAME: kaui
    DOCKER_BUILDKIT: 1
    JRUBY_OPTS: -J-Xmx10[2](https://github.com/killbill/killbill-admin-ui/actions/runs/10923884974/job/30321599252?pr=412#step:4:2)4M --debug
    KB_ADDRESS: 127.0.0.1
    KB_PORT: 8080
    RAILS_ENV: test
/home/runner/work/_temp/a[4](https://github.com/killbill/killbill-admin-ui/actions/runs/10923884974/job/30321599252?pr=412#step:4:4)2855b4-fdbb-48e7-97d4-e81ebedcb[5](https://github.com/killbill/killbill-admin-ui/actions/runs/10923884974/job/30321599252?pr=412#step:4:5)04.sh: line 2: docker-compose: command not found`