### PR TITLE
Remove login error when loading the login page

### DIFF
--- a/app/controllers/kaui/sessions_controller.rb
+++ b/app/controllers/kaui/sessions_controller.rb
@@ -11,6 +11,11 @@ module Kaui
 
     # The sign-in flow eventually calls authenticate! from config/initializers/killbill_authenticatable.rb
 
+    def new
+      flash.delete(:alert) if flash[:alert] == I18n.t('devise.failure.unauthenticated') && (stored_location_for(:user).nil? || flash[:notice].present?)
+      super
+    end
+
     rescue_from(StandardError) do |exception|
       Rails.logger.error(exception.message)
       Rails.logger.error(exception.backtrace.join("\n")) if exception.backtrace
@@ -29,7 +34,7 @@ module Kaui
 
     def after_sign_out_path_for(_resource)
       cookies.delete(:jwt_token)
-      kaui_path
+      new_user_session_path
     end
 
     def require_no_authentication

--- a/app/views/kaui/sessions/_form.html.erb
+++ b/app/views/kaui/sessions/_form.html.erb
@@ -4,6 +4,6 @@
 <%= render "kaui/components/form_password/form_password", f: f, field: :password, label: t("devise.sessions.new.password"), placeholder: "*****" %>
 
 <div class="d-grid mt-4">
-    <%= render "kaui/components/button/button", label: t("devise.sessions.new.log_in"), variant: "btn-primary custom-hover", type: "submit", html_class: "w-100" %>
+    <%= render "kaui/components/button/button", label: t("devise.sessions.new.sign_in"), variant: "btn-primary custom-hover", type: "submit", html_class: "w-100" %>
 </div>
 <% end %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,19 +3,19 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You are now logged in."
+      confirmed: "Your account was successfully confirmed. You are now signed in."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:
-      already_authenticated: "You are already logged in."
+      already_authenticated: "You are already signed in."
       inactive: "Your account was not activated yet."
       invalid: "Invalid username or password."
       invalid_token: "Invalid authentication token."
       locked: "Your account is locked."
       not_found_in_database: "Invalid username or password."
       killbill_not_available: "Kill Bill is unavailable"
-      timeout: "Your session expired, please log in again to continue."
-      unauthenticated: "You need to log in before continuing."
+      timeout: "Your session expired, please sign in again to continue."
+      unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your account before continuing."
     mailer:
       confirmation_instructions:
@@ -31,31 +31,31 @@ en:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions about how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password was changed successfully. You are now logged in."
+      updated: "Your password was changed successfully. You are now signed in."
       updated_not_active: "Your password was changed successfully."
     registrations:
       destroyed: "Bye! Your account was successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not log you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not log you in because your account is locked."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
       updated: "You updated your account successfully."
     sessions:
-      signed_in: "Logged in successfully."
-      signed_out: "Logged out successfully."
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
       new:
         username: "Username"
         password: "Password"
         enter_username: "Enter your username"
-        log_in: "Log in"
+        sign_in: "Sign in"
     unlocks:
       send_instructions: "You will receive an email with instructions about how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions about how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please log in to continue."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try logging in"
+      already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
       not_found: "not found"

--- a/test/integration/kaui/navigation_test.rb
+++ b/test/integration/kaui/navigation_test.rb
@@ -33,11 +33,11 @@ module Kaui
 
       # Verify log-out
       delete SIGN_OUT_PATH
-      assert_redirected_to "#{BASE_PATH}/"
+      assert_redirected_to SIGN_IN_PATH
 
       get BASE_PATH
       assert_redirected_to SIGN_IN_PATH
-      assert_equal 'You need to log in before continuing.', flash[:alert]
+      assert_equal 'You need to sign in before continuing.', flash[:alert]
     end
   end
 end


### PR DESCRIPTION
Number 2 in this issue: https://github.com/killbill/technical-support/issues/234
- Revert login -> sign in
- Update the error flash You need sign in before continue, only show it when user access the KAUI link without login.