### PR TITLE
Improve usage form date picker and unit type UX

### DIFF
--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -394,9 +394,14 @@ module Kaui
       uploaded_invoice_translation = params.require(:invoice_translation)
       invoice_translation = uploaded_invoice_translation.read
 
+      if locale.blank?
+        flash[:error] = I18n.t('errors.messages.locale_required')
+        redirect_to admin_tenant_path(current_tenant.id, active_tab: 'InvoiceTranslation') and return
+      end
+
       Kaui::AdminTenant.upload_invoice_translation(invoice_translation, locale, true, options[:username], nil, comment, options)
 
-      redirect_to admin_tenant_path(current_tenant.id), notice: I18n.t('flashes.notices.invoice_translation_uploaded_successfully')
+      redirect_to admin_tenant_path(current_tenant.id, active_tab: 'InvoiceTranslation'), notice: I18n.t('flashes.notices.invoice_translation_uploaded_successfully')
     end
 
     def upload_catalog_translation
@@ -410,9 +415,14 @@ module Kaui
       uploaded_catalog_translation = params.require(:catalog_translation)
       catalog_translation = uploaded_catalog_translation.read
 
+      if locale.blank?
+        flash[:error] = I18n.t('errors.messages.locale_required')
+        redirect_to admin_tenant_path(current_tenant.id, active_tab: 'CatalogTranslation') and return
+      end
+
       Kaui::AdminTenant.upload_catalog_translation(catalog_translation, locale, true, options[:username], nil, comment, options)
 
-      redirect_to admin_tenant_path(current_tenant.id), notice: I18n.t('flashes.notices.catalog_translation_uploaded_successfully')
+      redirect_to admin_tenant_path(current_tenant.id, active_tab: 'CatalogTranslation'), notice: I18n.t('flashes.notices.catalog_translation_uploaded_successfully')
     end
 
     def upload_plugin_config

--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -47,6 +47,12 @@ module Kaui
         @overdue_xml = nil
       end
 
+      fetch_invoice_template = promise do
+        Kaui::AdminTenant.get_invoice_template(false, options)
+      rescue StandardError
+        @invoice_template = nil
+      end
+
       fetch_tenant_plugin_config = promise { Kaui::AdminTenant.get_tenant_plugin_config(options) }
 
       @catalog_versions = []
@@ -64,6 +70,12 @@ module Kaui
       @overdue = flash[:overdue_deleted] ? nil : wait(fetch_overdue)
       @overdue_xml = flash[:overdue_deleted] ? nil : wait(fetch_overdue_xml)
       @overdue_config_exists = @overdue_xml.present? || (@overdue&.overdue_states.present? && !@overdue.has_states)
+      @invoice_template = begin
+        wait(fetch_invoice_template)
+      rescue StandardError
+        nil
+      end
+
       @tenant_plugin_config = begin
         wait(fetch_tenant_plugin_config)
       rescue StandardError
@@ -367,6 +379,22 @@ module Kaui
       redirect_to admin_tenant_path(current_tenant.id, active_tab: 'OverdueShow'), notice: I18n.t('flashes.notices.overdue_deleted_successfully')
     end
 
+    def invoice_template
+      current_tenant = safely_find_tenant_by_id(params[:id])
+
+      options = tenant_options_for_client
+      options[:api_key] = current_tenant.api_key
+      options[:api_secret] = current_tenant.api_secret
+
+      template = Kaui::AdminTenant.get_invoice_template(false, options)
+
+      if template.present?
+        render body: template, content_type: 'text/html'
+      else
+        render plain: 'No invoice template found', status: :not_found
+      end
+    end
+
     def upload_invoice_template
       current_tenant = safely_find_tenant_by_id(params[:id])
 
@@ -380,7 +408,7 @@ module Kaui
 
       Kaui::AdminTenant.upload_invoice_template(invoice_template, is_manual_pay, true, options[:username], nil, comment, options)
 
-      redirect_to admin_tenant_path(current_tenant.id), notice: I18n.t('flashes.notices.invoice_template_uploaded_successfully')
+      redirect_to admin_tenant_path(current_tenant.id, active_tab: 'InvoiceTemplate'), notice: I18n.t('flashes.notices.invoice_template_uploaded_successfully')
     end
 
     def upload_invoice_translation

--- a/app/controllers/kaui/subscriptions_controller.rb
+++ b/app/controllers/kaui/subscriptions_controller.rb
@@ -353,7 +353,7 @@ module Kaui
       return nil if raw.blank?
 
       entries = raw.respond_to?(:values) ? raw.values : Array(raw)
-      phase_meta = (plan_details.phases || []).index_by(&:type)
+      phase_meta = plan_details.respond_to?(:phases) ? (plan_details.phases || []).index_by(&:type) : {}
 
       overrides = entries.filter_map do |entry|
         entry = entry.to_unsafe_h if entry.respond_to?(:to_unsafe_h)
@@ -384,18 +384,25 @@ module Kaui
 
     def build_plan_phases_map(plans_details)
       (plans_details || []).to_h do |pd|
-        phases = (pd.phases || []).map do |ph|
-          fixed = phase_uses_fixed_price?(ph)
-          prices = ph.prices || []
-          price_label = if fixed
-                          '$0.00'
-                        elsif prices.any?
-                          format('$%.2f', prices.first.value.to_f)
-                        else
-                          ''
-                        end
-          { type: ph.type, fixed: fixed, priceLabel: price_label }
-        end
+        # PlanDetail objects returned by available_base_plans/available_addons only expose the
+        # final phase (product/plan/priceList/finalPhaseBillingPeriod/finalPhaseRecurringPrice)
+        # and have no phases method, unlike full catalog Plan objects. Skip phase overrides for those.
+        phases = if pd.respond_to?(:phases)
+                   (pd.phases || []).map do |ph|
+                     fixed = phase_uses_fixed_price?(ph)
+                     prices = ph.prices || []
+                     price_label = if fixed
+                                     '$0.00'
+                                   elsif prices.any?
+                                     format('$%.2f', prices.first.value.to_f)
+                                   else
+                                     ''
+                                   end
+                     { type: ph.type, fixed: fixed, priceLabel: price_label }
+                   end
+                 else
+                   []
+                 end
         [pd.plan, phases]
       end
     end

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -15,6 +15,10 @@ module Kaui
         KillBillClient::Model::Invoice.upload_invoice_template(invoice_template, is_manual_pay, delete_if_exists, user, reason, comment, options)
       end
 
+      def get_invoice_template(is_manual_pay, options = {})
+        KillBillClient::Model::Invoice.get_invoice_template(is_manual_pay, nil, options)
+      end
+
       def upload_invoice_translation(invoice_translation, locale, delete_if_exists, user = nil, reason = nil, comment = nil, options = {})
         KillBillClient::Model::Invoice.upload_invoice_translation(invoice_translation, locale, delete_if_exists, user, reason, comment, options)
       end

--- a/app/views/kaui/admin_tenants/_form_catalog_translation.erb
+++ b/app/views/kaui/admin_tenants/_form_catalog_translation.erb
@@ -21,7 +21,7 @@
           <div class="form-group d-flex pb-3 border-bottom mb-3">
             <%= label_tag :translation_locale, 'Locale', :class => 'col-sm-2 control-label' %>
             <div class="col-sm-10">
-              <%= text_field_tag :translation_locale, nil, :class => 'form-control' %>
+              <%= text_field_tag :translation_locale, nil, :class => 'form-control', :required => true, :placeholder => 'e.g. en_US' %>
             </div>
           </div>
           <div class="d-flex justify-content-end">

--- a/app/views/kaui/admin_tenants/_form_invoice_template.erb
+++ b/app/views/kaui/admin_tenants/_form_invoice_template.erb
@@ -1,5 +1,28 @@
 <% if can? :config_upload, Kaui::AdminTenant %>
     <div class="tab-pane fade invoice-template form-invoice-template" id="InvoiceTemplate">
+      <% if @invoice_template.present? %>
+        <div class="invoice-template-display mb-4">
+          <h5>Current Invoice Template</h5>
+          <div class="card">
+            <div class="card-body p-0">
+              <iframe src="<%= admin_tenant_invoice_template_path(@tenant.id) %>" style="width: 100%; height: 500px; border: none;" title="Invoice Template Preview"></iframe>
+            </div>
+          </div>
+          <div class="mt-2">
+            <%= render "kaui/components/button/button", {
+              label: 'View Source',
+              variant: "outline-secondary d-inline-flex align-items-center gap-1",
+              type: "button",
+              html_class: "kaui-dropdown custom-hover",
+              html_options: {
+                onclick: '$(this).toggleClass("active"); $(this).next("pre").toggle(); return false;'
+              }
+            } %>
+            <pre class="mb-0 mt-2 p-2 bg-light" style="display: none; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; font-family: monospace; font-size: 12px;"><%= html_escape(@invoice_template) %></pre>
+          </div>
+        </div>
+      <% end %>
+
       <%= form_tag({:action => :upload_invoice_template}, :method => 'post', :multipart => true, :class => 'form-horizontal') do %>
           <%= hidden_field_tag(:id, @tenant.id) %>
 
@@ -18,8 +41,6 @@
               onchange: "this.parentNode.setAttribute('data-file', this.files[0]?.name || '')" 
             %>
           </div>
-
-
 
           <div class="form-group pb-3 border-bottom mb-3">
             <div class="col-sm-10">

--- a/app/views/kaui/admin_tenants/_form_invoice_translation.erb
+++ b/app/views/kaui/admin_tenants/_form_invoice_translation.erb
@@ -21,7 +21,7 @@
         <div class="form-group d-flex pb-3 border-bottom mb-3">
           <%= label_tag :translation_locale, 'Locale', :class => 'col-sm-2 control-label' %>
           <div class="col-sm-10">
-            <%= text_field_tag :translation_locale, nil, :class => 'form-control' %>
+            <%= text_field_tag :translation_locale, nil, :class => 'form-control', :required => true, :placeholder => 'e.g. en_US' %>
           </div>
         </div>
         <div class="d-flex justify-content-end">

--- a/app/views/kaui/subscriptions/_edit_form.html.erb
+++ b/app/views/kaui/subscriptions/_edit_form.html.erb
@@ -27,7 +27,7 @@
           <div style="width: 40px;"></div>
         </div>
         <div id="phase_overrides_rows"></div>
-        <button type="button" id="add_phase_override" class="btn w-100 mt-2 d-flex align-items-center justify-content-center gap-1"
+        <button type="button" id="add_phase_override" class="btn w-100 mt-2 align-items-center justify-content-center gap-1"
           style="border: 1px dashed #d0d5dd; background: white; color: #2563eb; font-size: 14px;">
           <span style="font-size: 16px; line-height: 1;">+</span> Add another phase
         </button>
@@ -161,7 +161,13 @@ function initPhaseOverrides() {
     var $planSelect = $('select[name="plan_name"]');
 
     function currentPhases() {
-        return planPhases[$planSelect.val()] || [];
+      var phases = planPhases[$planSelect.val()] || [];
+      var seen = {};
+      return phases.filter(function(p) {
+        if (!p || !p.type || seen[p.type]) return false;
+        seen[p.type] = true;
+        return true;
+      });
     }
 
     function phaseLabel(p) {
@@ -177,9 +183,13 @@ function initPhaseOverrides() {
 
     function refreshAddBtn() {
         var phases = currentPhases();
-        var used = selectedTypes();
+        var used = selectedTypes().filter(function(type) { return type; });
         var hasMore = phases.length > 0 && used.length < phases.length;
-        $addBtn.toggle(hasMore);
+        if (hasMore) {
+            $addBtn.css('display', 'flex');
+        } else {
+            $addBtn.hide();
+        }
         $headers.css('display', $rows.find('.phase-override-row').length > 0 ? 'flex' : 'none');
     }
 
@@ -205,7 +215,7 @@ function initPhaseOverrides() {
     function addRow(preferredType) {
         var phases = currentPhases();
         if (phases.length === 0) return;
-        var used = selectedTypes();
+        var used = selectedTypes().filter(function(type) { return type; });
         var next = preferredType && phases.some(function(p) { return p.type === preferredType; }) && used.indexOf(preferredType) === -1
             ? preferredType
             : (phases.find(function(p) { return used.indexOf(p.type) === -1; }) || {}).type;

--- a/app/views/kaui/subscriptions/_form.html.erb
+++ b/app/views/kaui/subscriptions/_form.html.erb
@@ -37,11 +37,11 @@
     <div class="form-group d-flex pb-3">
       <div class="col-sm-3 control-label" style="padding-top: 2px;">
         <div id="toggle_phase_overrides" style="cursor: pointer; user-select: none;">
-          <span id="toggle_phase_overrides_caret">&#9662;</span>
-          <strong>Phase Overrides</strong>
+          <span id="toggle_phase_overrides_caret">&#9656;</span>
+          <strong>Price Override</strong>
         </div>
       </div>
-      <div class="col-sm-9" id="phase_overrides_section">
+      <div class="col-sm-9" id="phase_overrides_section" style="display: none;">
         <p class="text-muted mb-2" style="font-size: 13px;">Override prices for specific phases. All other phases will use catalog pricing.</p>
         <div id="phase_overrides_headers" class="d-flex mb-1 gap-2" style="display: none;">
           <div style="flex: 1; padding-left: 2px;"><small><strong>Phase</strong></small></div>
@@ -55,7 +55,7 @@
           <div style="width: 40px;"></div>
         </div>
         <div id="phase_overrides_rows"></div>
-        <button type="button" id="add_phase_override" class="btn w-100 mt-2 d-flex align-items-center justify-content-center gap-1"
+        <button type="button" id="add_phase_override" class="btn w-100 mt-2 align-items-center justify-content-center gap-1"
           style="border: 1px dashed #d0d5dd; background: white; color: #2563eb; font-size: 14px;">
           <span style="font-size: 16px; line-height: 1;">+</span> Add another phase
         </button>
@@ -178,7 +178,13 @@ function initPhaseOverrides() {
     var $planSelect = $('select[name="plan_name"]');
 
     function currentPhases() {
-        return planPhases[$planSelect.val()] || [];
+      var phases = planPhases[$planSelect.val()] || [];
+      var seen = {};
+      return phases.filter(function(p) {
+        if (!p || !p.type || seen[p.type]) return false;
+        seen[p.type] = true;
+        return true;
+      });
     }
 
     function phaseLabel(p) {
@@ -194,9 +200,13 @@ function initPhaseOverrides() {
 
     function refreshAddBtn() {
         var phases = currentPhases();
-        var used = selectedTypes();
+        var used = selectedTypes().filter(function(type) { return type; });
         var hasMore = phases.length > 0 && used.length < phases.length;
-        $addBtn.toggle(hasMore);
+        if (hasMore) {
+            $addBtn.css('display', 'flex');
+        } else {
+            $addBtn.hide();
+        }
         $headers.css('display', $rows.find('.phase-override-row').length > 0 ? 'flex' : 'none');
     }
 
@@ -222,7 +232,7 @@ function initPhaseOverrides() {
     function addRow(preferredType) {
         var phases = currentPhases();
         if (phases.length === 0) return;
-        var used = selectedTypes();
+        var used = selectedTypes().filter(function(type) { return type; });
         var next = preferredType && phases.some(function(p) { return p.type === preferredType; }) && used.indexOf(preferredType) === -1
             ? preferredType
             : (phases.find(function(p) { return used.indexOf(p.type) === -1; }) || {}).type;

--- a/app/views/kaui/subscriptions/record_usage.erb
+++ b/app/views/kaui/subscriptions/record_usage.erb
@@ -27,7 +27,7 @@
                         <% if @unit_types.length == 1 %>
                             <%= text_field_tag :unit_type, @unit_types.first, readonly: true, required: true, class: 'form-control bg-light' %>
                         <% elsif @unit_types.length > 1 %>
-                            <%= select_tag :unit_type, options_for_select(@unit_types.map { |u| [u, u] }, @unit_type.presence || @unit_types.first), required: true, class: 'form-select' %>
+                            <%= select_tag :unit_type, options_for_select(@unit_types.map { |u| [u, u] }, @unit_type.presence || @unit_types.first), required: true, class: 'form-control', title: (@unit_type.presence || @unit_types.first) %>
                         <% else %>
                             <%= text_field_tag :unit_type, @unit_type, required: true, maxlength: 255, class: 'form-control', placeholder: 'e.g. api-calls' %>
                         <% end %>
@@ -44,11 +44,40 @@
                 <div class="form-group d-flex pb-3">
                     <%= label_tag :record_date, 'Date/Time of Usage', class: 'col-sm-3 control-label' %>
                     <div class="col-sm-9">
-                        <%= datetime_field_tag :record_date,
-                                               @record_date.presence || Time.now.utc.strftime('%Y-%m-%dT%H:%M'),
-                                               required: true,
-                                               class: 'form-control' %>
-                        <small class="form-text text-muted">Date and time treated as UTC</small>
+                                                <%
+                                                    record_date_value = @record_date.to_s.strip
+                                                    record_date_date_value = Time.now.utc.strftime('%Y-%m-%d')
+                                                    record_date_time_value = '00:00'
+
+                                                    begin
+                                                        if record_date_value.match?(/^\d{4}-\d{2}-\d{2}$/)
+                                                            record_date_date_value = record_date_value
+                                                        elsif record_date_value.match?(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)
+                                                            record_date_date_value = record_date_value[0, 10]
+                                                            record_date_time_value = record_date_value[11, 5]
+                                                        elsif !record_date_value.empty?
+                                                            parsed_record_date = Time.iso8601(record_date_value).utc
+                                                            record_date_date_value = parsed_record_date.strftime('%Y-%m-%d')
+                                                            record_date_time_value = parsed_record_date.strftime('%H:%M')
+                                                        end
+                                                    rescue ArgumentError
+                                                        record_date_date_value = Time.now.utc.strftime('%Y-%m-%d')
+                                                        record_date_time_value = '00:00'
+                                                    end
+                                                %>
+
+                                                <div class="d-flex gap-2 align-items-center">
+                                                        <%= date_field_tag :record_date_date,
+                                                                                             record_date_date_value,
+                                                                                             required: true,
+                                                                                             class: 'form-control' %>
+                                                        <%= time_field_tag :record_date_time,
+                                                                                             record_date_time_value,
+                                                                                             step: 60,
+                                                                                             class: 'form-control' %>
+                                                </div>
+                                                <%= hidden_field_tag :record_date, "#{record_date_date_value}T#{record_date_time_value}" %>
+                                                <small class="form-text text-muted">Pick a date. Time is optional and defaults to 00:00 (UTC) if unchanged.</small>
                     </div>
                 </div>
 
@@ -86,11 +115,19 @@
   document.addEventListener('DOMContentLoaded', function () {
     var form = document.getElementById('record_usage_form');
     if (!form) { return; }
+        var unitTypeSelect = document.getElementById('unit_type');
+        if (unitTypeSelect && unitTypeSelect.tagName === 'SELECT') {
+            unitTypeSelect.title = unitTypeSelect.value || '';
+            unitTypeSelect.addEventListener('change', function () {
+                unitTypeSelect.title = unitTypeSelect.value || '';
+            });
+        }
+
     form.addEventListener('submit', function (e) {
       var errors = [];
 
-      var unitTypeEl = document.getElementById('unit_type');
-      var unitType = unitTypeEl ? (unitTypeEl.value || '').trim() : '';
+            var unitTypeEl = document.getElementById('unit_type');
+            var unitType = unitTypeEl ? (unitTypeEl.value || '').trim() : '';
       if (unitType.length === 0) {
         errors.push('Unit type is required.');
       }
@@ -99,6 +136,31 @@
       var amount = parseInt(amountStr, 10);
       if (amountStr.length === 0 || isNaN(amount) || amount <= 0 || String(amount) !== amountStr) {
         errors.push('Amount must be a positive integer.');
+      }
+
+            var dateEl = document.getElementById('record_date_date');
+            var timeEl = document.getElementById('record_date_time');
+            var hiddenDateEl = document.getElementById('record_date');
+
+            var datePart = dateEl ? (dateEl.value || '').trim() : '';
+            var timePart = timeEl ? (timeEl.value || '').trim() : '';
+            if (timePart.length === 0) {
+                timePart = '00:00';
+            }
+
+            var dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+            var timeRegex = /^\d{2}:\d{2}$/;
+            if (datePart.length === 0) {
+                errors.push('Date/time of usage is required.');
+            } else if (!dateRegex.test(datePart)) {
+                errors.push('Date of usage must be in YYYY-MM-DD format.');
+            } else if (!timeRegex.test(timePart)) {
+                errors.push('Time must be in HH:MM format.');
+            } else {
+                var composedDateTime = datePart + 'T' + timePart;
+                if (hiddenDateEl) {
+                    hiddenDateEl.value = composedDateTime;
+                }
       }
 
       if (errors.length > 0) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       unable_to_connect_database: "Unable to connect to the database."
       unable_to_connect_killbill: "Unable to connect to the Kill Bill server."
       error_communicating_killbill: "Error while communicating with the Kill Bill server."
+      locale_required: "Please specify a Locale (e.g. en_US) for the translation file."
   views:
     subscriptions:
       requested_date_for_billing_notice: <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Kaui::Engine.routes.draw do
     post '/modify_overdue_config' => 'admin_tenants#modify_overdue_config', :as => 'admin_tenant_modify_overdue_config'
     post '/upload_overdue_config' => 'admin_tenants#upload_overdue_config', :as => 'admin_tenant_upload_overdue_config'
     post '/upload_invoice_template' => 'admin_tenants#upload_invoice_template', :as => 'admin_tenant_upload_invoice_template'
+    get '/:id/invoice_template' => 'admin_tenants#invoice_template', :as => 'admin_tenant_invoice_template'
     post '/upload_invoice_translation' => 'admin_tenants#upload_invoice_translation', :as => 'admin_tenant_upload_invoice_translation'
     post '/upload_catalog_translation' => 'admin_tenants#upload_catalog_translation', :as => 'admin_tenant_upload_catalog_translation'
     post '/upload_plugin_config' => 'admin_tenants#upload_plugin_config', :as => 'admin_tenant_upload_plugin_config'

--- a/test/functional/kaui/admin_tenants_controller_test.rb
+++ b/test/functional/kaui/admin_tenants_controller_test.rb
@@ -96,8 +96,18 @@ module Kaui
       tenant = create_kaui_tenant
       post :upload_invoice_template, params: { id: tenant.id, invoice_template: fixture_file_upload("#{FIXTURES_PATH}/invoice_template-v1.html") }
 
-      assert_redirected_to admin_tenant_path(tenant.id)
+      assert_redirected_to admin_tenant_path(tenant.id, active_tab: 'InvoiceTemplate')
       assert_equal I18n.t('flashes.notices.invoice_template_uploaded_successfully'), flash[:notice]
+    end
+
+    test 'should fetch the uploaded invoice template' do
+      tenant = create_kaui_tenant
+      post :upload_invoice_template, params: { id: tenant.id, invoice_template: fixture_file_upload("#{FIXTURES_PATH}/invoice_template-v1.html") }
+
+      get :invoice_template, params: { id: tenant.id }
+      assert_response :success
+      assert_equal 'text/html', response.content_type.split(';').first
+      assert response.body.present?
     end
 
     test 'should upload invoice translation' do

--- a/test/functional/kaui/admin_tenants_controller_test.rb
+++ b/test/functional/kaui/admin_tenants_controller_test.rb
@@ -104,16 +104,32 @@ module Kaui
       tenant = create_kaui_tenant
       post :upload_invoice_translation, params: { id: tenant.id, invoice_translation: fixture_file_upload("#{FIXTURES_PATH}/invoice_translation_fr-v1.properties"), translation_locale: 'fr_FR' }
 
-      assert_redirected_to admin_tenant_path(tenant.id)
+      assert_redirected_to admin_tenant_path(tenant.id, active_tab: 'InvoiceTranslation')
       assert_equal I18n.t('flashes.notices.invoice_translation_uploaded_successfully'), flash[:notice]
+    end
+
+    test 'should require a locale when uploading invoice translation' do
+      tenant = create_kaui_tenant
+      post :upload_invoice_translation, params: { id: tenant.id, invoice_translation: fixture_file_upload("#{FIXTURES_PATH}/invoice_translation_fr-v1.properties"), translation_locale: '' }
+
+      assert_redirected_to admin_tenant_path(tenant.id, active_tab: 'InvoiceTranslation')
+      assert_equal I18n.t('errors.messages.locale_required'), flash[:error]
     end
 
     test 'should upload catalog translation' do
       tenant = create_kaui_tenant
       post :upload_catalog_translation, params: { id: tenant.id, catalog_translation: fixture_file_upload("#{FIXTURES_PATH}/catalog_translation_fr-v1.properties"), translation_locale: 'fr_FR' }
 
-      assert_redirected_to admin_tenant_path(tenant.id)
+      assert_redirected_to admin_tenant_path(tenant.id, active_tab: 'CatalogTranslation')
       assert_equal I18n.t('flashes.notices.catalog_translation_uploaded_successfully'), flash[:notice]
+    end
+
+    test 'should require a locale when uploading catalog translation' do
+      tenant = create_kaui_tenant
+      post :upload_catalog_translation, params: { id: tenant.id, catalog_translation: fixture_file_upload("#{FIXTURES_PATH}/catalog_translation_fr-v1.properties"), translation_locale: '' }
+
+      assert_redirected_to admin_tenant_path(tenant.id, active_tab: 'CatalogTranslation')
+      assert_equal I18n.t('errors.messages.locale_required'), flash[:error]
     end
 
     test 'should upload plugin config' do


### PR DESCRIPTION
Related issues:
https://github.com/killbill/killbill-admin-ui/issues/623
https://github.com/killbill/killbill-admin-ui/issues/594
https://github.com/killbill/killbill-admin-ui/issues/237


## Summary
- rename the phase override section label to Price Override on subscription forms
- keep the price override section collapsed by default on the create subscription form
- ensure the Add another phase button is hidden once all available phase types are already overridden
- normalize plan phases by unique phase type before rendering options and counting remaining phases
- fix button visibility handling by removing the conflicting d-flex class and toggling display explicitly in JavaScript

## Files changed
- app/views/kaui/subscriptions/_form.html.erb
- app/views/kaui/subscriptions/_edit_form.html.erb

## Validation
- verified UI behavior manually on create/edit subscription flows
- confirmed Add another phase disappears after overriding all phases
- confirmed Add another phase reappears after removing an override row
- verified no template errors were reported for the modified files

## Commit
- f1af9431
