### PR TITLE
Add Usage navigation entry points for Aviate metering screens

### DIFF
--- a/app/views/kaui/layouts/kaui_account_navbar.html.erb
+++ b/app/views/kaui/layouts/kaui_account_navbar.html.erb
@@ -6,6 +6,7 @@
     <%= link_to 'Account', kaui_engine.account_path(params[:account_id]), :class => (params[:controller].ends_with?('accounts') ? 'current' : 'non-current') %>
     <% if aviate_plugin_installed %>
       <%= link_to 'Wallets', aviate_engine.account_wallets_path(params[:account_id]), :class => (params[:controller].ends_with?('wallets') ? 'current' : 'non-current') %>
+      <%= link_to 'Usage', aviate_engine.account_usage_index_path(params[:account_id]), :class => (params[:controller].ends_with?('usage') ? 'current' : 'non-current') %>
     <% end %>
     <%= link_to 'Subscriptions', kaui_engine.account_bundles_path(params[:account_id]), :class => (params[:controller].ends_with?('bundles') ? 'current' : 'non-current') %>
     <%= link_to 'Invoices', kaui_engine.account_invoices_path(params[:account_id]), :class => (params[:controller].ends_with?('invoices') ? 'current' : 'non-current') %>

--- a/app/views/kaui/layouts/kaui_account_sidebar.html.erb
+++ b/app/views/kaui/layouts/kaui_account_sidebar.html.erb
@@ -15,6 +15,7 @@
 
       <% if aviate_plugin_installed %>
         <% menu_items << { label: 'Wallets', path: aviate_engine.account_wallets_path(params[:account_id]), controller_suffix: 'wallets', icon_path: 'kaui/sidebar/invoices.svg' } %>
+        <% menu_items << { label: 'Usage', path: aviate_engine.account_usage_index_path(params[:account_id]), controller_suffix: 'usage', icon_path: 'kaui/sidebar/subscriptions.svg' } %>
       <% end %>
 
       <% if current_user.root? %>

--- a/app/views/kaui/subscriptions/_subscriptions_table.html.erb
+++ b/app/views/kaui/subscriptions/_subscriptions_table.html.erb
@@ -215,6 +215,14 @@
                     path: kaui_engine.record_usage_path(id: sub.subscription_id),
                     icon: "kaui/subscription/change.svg"
                   } %>
+
+                  <% if aviate_plugin_installed %>
+                    <% menu_items << {
+                      label: "View Usage",
+                      path: aviate_engine.usage_subscription_path(id: sub.subscription_id),
+                      icon: "kaui/subscription/change.svg"
+                    } %>
+                  <% end %>
                 <% end %>
 
                 <% if can?(:transfer, Kaui::Bundle) && sub.product_category != 'ADD_ON' %>


### PR DESCRIPTION
## Summary
Adds navigation entry points into the Aviate metering/usage pages (implemented in killbill-aviate-ui) that were previously unreachable from Kaui's UI.

- "Usage" link in the account sidebar and top navbar, gated by the existing `aviate_plugin_installed` helper (same gating as the "Wallets" link).
- "View Usage" dots-menu item per subscription row in the bundles/subscriptions table, linking directly to that subscription's Aviate usage page.

## Related
- killbill/technical-support#206
- Companion PRs: killbill-admin-ui-standalone (asset manifest fix), killbill-aviate-ui (usage feature + bug fixes)