### PR TITLE
Fix Edit Columns settings not persisting across sessions and set demo-friendly defaults

### DIFF
--- a/app/controllers/kaui/accounts_controller.rb
+++ b/app/controllers/kaui/accounts_controller.rb
@@ -17,7 +17,7 @@ module Kaui
         return
       end
       @search_fields = Kaui::Account::ADVANCED_SEARCH_COLUMNS.map { |attr| [attr, attr.split('_').join(' ').capitalize] }
-      @dropdown_default = default_columns(Kaui.account_search_columns.call[2], Kaui::Account::SENSIVITE_DATA_FIELDS)
+      @dropdown_default = default_columns(Kaui.account_search_columns.call[2], Kaui::Account::DEFAULT_VISIBLE_COLUMNS)
       @visible_columns = @dropdown_default
 
       @ordering = params[:ordering] || (@search_query.blank? ? 'desc' : 'asc')
@@ -47,7 +47,7 @@ module Kaui
         Kaui.account_search_columns.call(account, view_context)[1]
       end
 
-      paginate searcher, data_extractor, formatter, default_columns(Kaui.account_search_columns.call[2], Kaui::Account::SENSIVITE_DATA_FIELDS)
+      paginate searcher, data_extractor, formatter, default_columns(Kaui.account_search_columns.call[2], Kaui::Account::DEFAULT_VISIBLE_COLUMNS)
     end
 
     def download

--- a/app/controllers/kaui/engine_controller_util.rb
+++ b/app/controllers/kaui/engine_controller_util.rb
@@ -204,7 +204,7 @@ module Kaui
     end
 
     def default_columns(fields, visible_fields)
-      fields.map { |field| { data: fields.index(field), visible: visible_fields.include?(field) } }
+      fields.each_with_index.map { |field, index| { data: index, visible: visible_fields.include?(field) } }
     end
   end
 end

--- a/app/controllers/kaui/engine_controller_util.rb
+++ b/app/controllers/kaui/engine_controller_util.rb
@@ -203,8 +203,8 @@ module Kaui
       render json: response, status: response_status
     end
 
-    def default_columns(fields, sensivite_fields)
-      fields.map { |field| { data: fields.index(field), visible: !(sensivite_fields.include? field) } }
+    def default_columns(fields, visible_fields)
+      fields.map { |field| { data: fields.index(field), visible: visible_fields.include?(field) } }
     end
   end
 end

--- a/app/controllers/kaui/invoices_controller.rb
+++ b/app/controllers/kaui/invoices_controller.rb
@@ -10,6 +10,8 @@ module Kaui
       @offset = params[:offset] || 0
       @limit = params[:limit] || 50
       @search_fields = Kaui::Invoice::ADVANCED_SEARCH_COLUMNS.map { |attr| [attr, attr.split('_').join(' ').capitalize] }
+      @dropdown_default = default_columns(Kaui.account_invoices_columns.call[3], Kaui::Invoice::DEFAULT_VISIBLE_COLUMNS)
+      @visible_columns = @dropdown_default
 
       @max_nb_records = @search_query.blank? ? Kaui::Invoice.list_or_search(nil, 0, 0, options_for_klient).pagination_max_nb_records : 0
     end

--- a/app/controllers/kaui/payments_controller.rb
+++ b/app/controllers/kaui/payments_controller.rb
@@ -11,6 +11,8 @@ module Kaui
       @offset = params[:offset] || 0
       @limit = params[:limit] || 50
       @search_fields = Kaui::Payment::ADVANCED_SEARCH_COLUMNS.map { |attr| [attr, attr.split('_').join(' ').capitalize] }
+      @dropdown_default = default_columns(Kaui.account_payments_columns.call[3], Kaui::Payment::DEFAULT_VISIBLE_COLUMNS)
+      @visible_columns = @dropdown_default
 
       @max_nb_records = @search_query.blank? ? Kaui::Payment.list_or_search(nil, 0, 0, options_for_klient).pagination_max_nb_records : 0
     end

--- a/app/models/kaui/account.rb
+++ b/app/models/kaui/account.rb
@@ -4,7 +4,9 @@ module Kaui
   class Account < KillBillClient::Model::Account
     attr_accessor :phone, :bill_cycle_day_local
 
-    SENSIVITE_DATA_FIELDS = %w[name email].freeze
+    # Columns shown by default on the Accounts list screen (demo-friendly defaults); the rest remain
+    # available but hidden until the user opts in via "Edit Columns".
+    DEFAULT_VISIBLE_COLUMNS = %w[name account_id external_key currency time_zone locale account_balance account_cba].freeze
     REMAPPING_FIELDS = {
       'is_payment_delegated_to_parent' => 'pay_via_parent',
       'account_balance' => 'balance',

--- a/app/models/kaui/invoice.rb
+++ b/app/models/kaui/invoice.rb
@@ -3,6 +3,9 @@
 module Kaui
   class Invoice < KillBillClient::Model::Invoice
     TABLE_IGNORE_COLUMNS = %w[amount balance credit_adj refund_adj items is_parent_invoice parent_invoice_id parent_account_id audit_logs bundle_keys].freeze
+    # Columns shown by default on the Invoices list screen (demo-friendly defaults); the rest remain
+    # available but hidden until the user opts in via "Edit Columns".
+    DEFAULT_VISIBLE_COLUMNS = %w[invoice_number invoice_id status invoice_date target_date currency account_id].freeze
     ADVANCED_SEARCH_COLUMNS = %w[id account_id invoice_date target_date currency status balance].freeze
     ADVANCED_SEARCH_NAME_CHANGES = [%w[ac_id account_id]].freeze
 

--- a/app/models/kaui/payment.rb
+++ b/app/models/kaui/payment.rb
@@ -7,6 +7,9 @@ module Kaui
     attr_accessor :payment_date, :target_invoice_id
 
     TRANSACTION_STATUSES = %w[SUCCESS PENDING PAYMENT_FAILURE PLUGIN_FAILURE UNKNOWN].freeze
+    # Columns shown by default on the Payments list screen (demo-friendly defaults); the rest remain
+    # available but hidden until the user opts in via "Edit Columns".
+    DEFAULT_VISIBLE_COLUMNS = %w[payment_date payment_number status account_id currency purchased_amount refunded_amount credited_amount].freeze
     REMAPPING_FIELDS = {
       'auth_amount' => 'auth',
       'captured_amount' => 'capture',

--- a/app/views/kaui/accounts/_functions_bar.html.erb
+++ b/app/views/kaui/accounts/_functions_bar.html.erb
@@ -378,7 +378,7 @@ $(document).ready(function() {
   updateDropdownOrder();
 
   function updateDropdownOrder() {
-    var state = JSON.parse(localStorage.getItem('DataTables_accounts-table_' + window.location.pathname));
+    var state = JSON.parse(localStorage.getItem('DataTables_accounts-table-v2_' + window.location.pathname));
     if (state === null) {
       // On initial load, ensure the existing checkboxes work
       setupColumnToggleEvents();
@@ -393,7 +393,7 @@ $(document).ready(function() {
 
     if (columnOrder !== undefined) {
       $list.empty();
-      var state = JSON.parse(localStorage.getItem('DataTables_accounts-table_' + window.location.pathname));
+      var state = JSON.parse(localStorage.getItem('DataTables_accounts-table-v2_' + window.location.pathname));
       if (state !== null) {
         var colsOrder = state.ColReorder;
       }

--- a/app/views/kaui/accounts/_multi_functions_bar.html.erb
+++ b/app/views/kaui/accounts/_multi_functions_bar.html.erb
@@ -319,7 +319,7 @@ $(document).ready(function() {
   updateDropdownOrder();
 
   function updateDropdownOrder() {
-    var state = JSON.parse(localStorage.getItem('DataTables_accounts-table_' + window.location.pathname));
+    var state = JSON.parse(localStorage.getItem('DataTables_accounts-table-v2_' + window.location.pathname));
     if (state === null) {
       return;
     }
@@ -332,7 +332,7 @@ $(document).ready(function() {
 
     if (columnOrder !== undefined) {
       $list.empty();
-      var state = JSON.parse(localStorage.getItem('DataTables_accounts-table_' + window.location.pathname));
+      var state = JSON.parse(localStorage.getItem('DataTables_accounts-table-v2_' + window.location.pathname));
       if (state !== null) {
         var colsOrder = state.ColReorder;
       }

--- a/app/views/kaui/accounts/index.html.erb
+++ b/app/views/kaui/accounts/index.html.erb
@@ -79,11 +79,12 @@ $(document).ready(function() {
       "enable": false
     },
     "stateSave": true,
+    "stateDuration": -1,
     "stateSaveCallback": function(settings, data) {
-      localStorage.setItem('DataTables_accounts-table_' + window.location.pathname, JSON.stringify(data));
+      localStorage.setItem('DataTables_accounts-table-v2_' + window.location.pathname, JSON.stringify(data));
     },
     "stateLoadCallback": function(settings) {
-      return JSON.parse(localStorage.getItem('DataTables_accounts-table_' + window.location.pathname));
+      return JSON.parse(localStorage.getItem('DataTables_accounts-table-v2_' + window.location.pathname));
     },
     "scrollX": true,
     "dom": "<'row'r>t<'row'<'col-md-6'i><'col-md-6'p>>",

--- a/app/views/kaui/invoices/_multi_functions_bar.html.erb
+++ b/app/views/kaui/invoices/_multi_functions_bar.html.erb
@@ -52,7 +52,7 @@
       <%  Kaui.account_invoices_columns.call[0].each_with_index do |title, index| %>
           <li class="list-group-item-manual" data-id="<%= index %>">
             <label class="label-group-item-manual">
-              <input type="checkbox" class="column-toggle" draggable="true" data-column="<%= index %>" checked> 
+              <input type="checkbox" class="column-toggle" draggable="true" data-column="<%= index %>" <%= 'checked' if @dropdown_default[index][:visible] %>> 
               <%= title %>
               <span class="icon-drag" aria-hidden="true"></span>
             </label>
@@ -337,7 +337,7 @@ $(document).ready(function() {
   updateDropdownOrder();
 
   function loadState() {
-    var state = JSON.parse(localStorage.getItem('DataTables_invoices-table'));
+    var state = JSON.parse(localStorage.getItem('DataTables_invoices-table-v2'));
     return state || { columns: [], columnOrder: [] };
   }
 

--- a/app/views/kaui/invoices/index.html.erb
+++ b/app/views/kaui/invoices/index.html.erb
@@ -50,7 +50,7 @@ $(document).ready(function() {
     }
   });
 
-  var stateKey = 'DataTables_invoices-table';
+  var stateKey = 'DataTables_invoices-table-v2';
   var state = JSON.parse(localStorage.getItem(stateKey));
   if (state) {
     state.start = <%= @offset %>;
@@ -63,6 +63,7 @@ $(document).ready(function() {
       "enable": false
     },
     "stateSave": true,
+    "stateDuration": -1,
     "stateSaveCallback": function(settings, data) {
       localStorage.setItem(stateKey, JSON.stringify(data));
     },
@@ -99,7 +100,8 @@ $(document).ready(function() {
         });
         return reorderedData;
       }
-    }
+    },
+    "columns": <%= raw @visible_columns.to_json %>
   });
 
   // If the page loaded with advanced search params in the URL (e.g. restored from

--- a/app/views/kaui/payments/_multi_functions_bar.html.erb
+++ b/app/views/kaui/payments/_multi_functions_bar.html.erb
@@ -52,7 +52,7 @@
       <%  Kaui.account_payments_columns.call()[0].each_with_index do |title, index| %>
           <li class="list-group-item-manual" data-id="<%= index %>">
             <label class="label-group-item-manual">
-              <input type="checkbox" class="column-toggle" draggable="true" data-column="<%= index %>" checked> 
+              <input type="checkbox" class="column-toggle" draggable="true" data-column="<%= index %>" <%= 'checked' if @dropdown_default[index][:visible] %>> 
               <%= title %>
               <span class="icon-drag" aria-hidden="true"></span>
             </label>
@@ -338,7 +338,7 @@ $(document).ready(function() {
   updateDropdownOrder();
 
   function loadState() {
-    var state = JSON.parse(localStorage.getItem('DataTables_payments-table'));
+    var state = JSON.parse(localStorage.getItem('DataTables_payments-table-v2'));
     return state || { columns: [], columnOrder: [] };
   }
 

--- a/app/views/kaui/payments/index.html.erb
+++ b/app/views/kaui/payments/index.html.erb
@@ -56,10 +56,10 @@ $(document).ready(function() {
     "stateSave": true,
     "stateDuration": -1,
     "stateSaveCallback": function(settings, data) {
-      localStorage.setItem('DataTables_payments-table-v2', JSON.stringify(data));
+      localStorage.setItem(stateKey, JSON.stringify(data));
     },
     "stateLoadCallback": function(settings) {
-      return JSON.parse(localStorage.getItem('DataTables_payments-table-v2'));
+      return JSON.parse(localStorage.getItem(stateKey));
     },
     "scrollX": true,
     <% if @account.account_id.blank? %>

--- a/app/views/kaui/payments/index.html.erb
+++ b/app/views/kaui/payments/index.html.erb
@@ -41,7 +41,7 @@
 
 <%= javascript_tag do %>
 $(document).ready(function() {
-  var stateKey = 'DataTables_payments-table';
+  var stateKey = 'DataTables_payments-table-v2';
   var state = JSON.parse(localStorage.getItem(stateKey));
   if (state) {
     state.start = <%= @offset %>;
@@ -54,11 +54,12 @@ $(document).ready(function() {
       "enable": false
     },
     "stateSave": true,
+    "stateDuration": -1,
     "stateSaveCallback": function(settings, data) {
-      localStorage.setItem('DataTables_payments-table', JSON.stringify(data));
+      localStorage.setItem('DataTables_payments-table-v2', JSON.stringify(data));
     },
     "stateLoadCallback": function(settings) {
-      return JSON.parse(localStorage.getItem('DataTables_payments-table'));
+      return JSON.parse(localStorage.getItem('DataTables_payments-table-v2'));
     },
     "scrollX": true,
     <% if @account.account_id.blank? %>
@@ -115,6 +116,7 @@ $(document).ready(function() {
     "processing": true,
     "serverSide": true,
     "search": {"search": "<%= @search_query %>"},
+    "columns": <%= raw @visible_columns.to_json %>
   });
 
   // If the page loaded with advanced search params in the URL (e.g. restored from

--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -66,6 +66,8 @@ module Kaui
     # Add additional fields if needed
     fields = original_fields.dup
     fields -= %w[audit_logs first_name_length]
+    # Demo-friendly default column order (see Kaui::Account::DEFAULT_VISIBLE_COLUMNS for the ones shown by default)
+    fields = Kaui::Account::DEFAULT_VISIBLE_COLUMNS + (fields - Kaui::Account::DEFAULT_VISIBLE_COLUMNS)
     headers = fields.dup
     Kaui::Account::REMAPPING_FIELDS.each do |k, v|
       headers[fields.index(k)] = v
@@ -115,8 +117,8 @@ module Kaui
     fields = KillBillClient::Model::InvoiceAttributes.instance_variable_get(:@json_attributes)
     # Change the order if needed
     fields -= Kaui::Invoice::TABLE_IGNORE_COLUMNS
-    fields.delete('invoice_id')
-    fields.unshift('invoice_id')
+    # Demo-friendly default column order (see Kaui::Invoice::DEFAULT_VISIBLE_COLUMNS for the ones shown by default)
+    fields = Kaui::Invoice::DEFAULT_VISIBLE_COLUMNS + (fields - Kaui::Invoice::DEFAULT_VISIBLE_COLUMNS)
 
     headers = fields.map { |attr| attr.split('_').join(' ').capitalize }
     # Add additional headers if needed
@@ -146,16 +148,16 @@ module Kaui
 
     raw_data = fields.map { |attr| invoice&.send(attr.downcase) }
 
-    [headers, values, raw_data]
+    [headers, values, raw_data, fields]
   end
 
   self.account_payments_columns = lambda do |account = nil, payment = nil, view_context = nil|
     fields = KillBillClient::Model::PaymentAttributes.instance_variable_get(:@json_attributes)
     # Change the order if needed
-    fields = %w[payment_date] + fields
-    fields -= %w[payment_number transactions audit_logs]
-    fields.unshift('status')
-    fields.unshift('payment_number')
+    fields = %w[payment_date status] + fields
+    fields -= %w[transactions audit_logs]
+    # Demo-friendly default column order (see Kaui::Payment::DEFAULT_VISIBLE_COLUMNS for the ones shown by default)
+    fields = Kaui::Payment::DEFAULT_VISIBLE_COLUMNS + (fields - Kaui::Payment::DEFAULT_VISIBLE_COLUMNS)
 
     headers = fields.dup
     Kaui::Payment::REMAPPING_FIELDS.each do |k, v|
@@ -163,7 +165,7 @@ module Kaui
     end
     headers.map! { |attr| attr.split('_').join(' ').capitalize }
 
-    return [headers, []] if payment.nil?
+    return [headers, [], [], fields] if payment.nil?
 
     values = fields.map do |attr|
       case attr
@@ -190,7 +192,7 @@ module Kaui
     end
 
     # Add additional values if needed
-    [headers, values, raw_data]
+    [headers, values, raw_data, fields]
   end
 
   self.account_audit_logs_columns = lambda do

--- a/test/functional/kaui/invoices_controller_test.rb
+++ b/test/functional/kaui/invoices_controller_test.rb
@@ -7,6 +7,14 @@ module Kaui
     test 'should get index' do
       get :index, params: { account_id: @invoice_item.account_id }
       assert_response :ok
+
+      assert_not_nil assigns(:dropdown_default)
+      assert_not_nil assigns(:visible_columns)
+      assert_equal assigns(:dropdown_default), assigns(:visible_columns)
+
+      fields = Kaui.account_invoices_columns.call[3]
+      visible_fields = assigns(:dropdown_default).each_with_index.select { |column, _index| column[:visible] }.map { |_column, index| fields[index] }
+      assert_equal Kaui::Invoice::DEFAULT_VISIBLE_COLUMNS, visible_fields
     end
 
     test 'should list invoices' do

--- a/test/functional/kaui/payments_controller_test.rb
+++ b/test/functional/kaui/payments_controller_test.rb
@@ -7,6 +7,14 @@ module Kaui
     test 'should get index' do
       get :index, params: { account_id: @invoice_item.account_id }
       assert_response :ok
+
+      assert_not_nil assigns(:dropdown_default)
+      assert_not_nil assigns(:visible_columns)
+      assert_equal assigns(:dropdown_default), assigns(:visible_columns)
+
+      fields = Kaui.account_payments_columns.call[3]
+      visible_fields = assigns(:dropdown_default).each_with_index.select { |column, _index| column[:visible] }.map { |_column, index| fields[index] }
+      assert_equal Kaui::Payment::DEFAULT_VISIBLE_COLUMNS, visible_fields
     end
 
     test 'should list payments' do


### PR DESCRIPTION
## Summary

Fixes killbill/killbill-admin-ui#626

- Settings not surviving logout/sessions: DataTables' `stateSave` defaults to a 2-hour `stateDuration`, after which saved column state in `localStorage` is discarded. Added `stateDuration: -1` to the Accounts, Invoices, and Payments DataTables so column settings never expire.
- Versioned the `localStorage` state keys (`-v2` suffix) so stale state saved under the old column order/visibility (from before this fix) is discarded instead of being mis-applied.
- Added demo-friendly default columns/ordering per the issue screenshots:
  - Accounts: Name, Account Id, External Key, Currency, Time Zone, Locale, Balance, Cba
  - Invoices: Invoice Number, Invoice Id, Status, Invoice Date, Target Date, Currency, Account Id
  - Payments: Payment Date, Payment Number, Status, Account Id, Currency, Purchase, Refund, Credit
- Wired up default column visibility for the Invoices/Payments screens (previously only Accounts computed a default; Invoices/Payments always showed every column).

## Test plan

See manual test steps in the linked issue discussion. In short: clear `localStorage`, verify each screen shows the new default columns/order, customize columns, reload, log out/in, and confirm the customization persists.