### PR TITLE
Add existing invoice translations table to Invoice Translation tab

### DIFF
--- a/app/assets/stylesheets/kaui/tenants.css
+++ b/app/assets/stylesheets/kaui/tenants.css
@@ -641,6 +641,59 @@
   color: #414651;
 }
 
+/* app/views/kaui/admin_tenants/_form_invoice_translation.erb */
+
+.existing-invoice-translations-container {
+  max-width: 80rem;
+  width: 100%;
+}
+
+.existing-invoice-translations-container .existing-invoice-translations-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  padding: 0;
+  border-bottom: 0.0625rem solid #E9EAEB;
+}
+
+.existing-invoice-translations-container .existing-invoice-translations-header h2 {
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: #414651;
+  margin-bottom: 1.25rem;
+}
+
+.existing-invoice-translations-container table.existing-invoice-translations-table {
+  overflow-x: auto;
+  min-width: 100%;
+  border: none !important;
+}
+
+.existing-invoice-translations-container table.existing-invoice-translations-table tbody tr {
+  border-bottom: 0.0625rem solid #E9EAEB !important;
+}
+
+.existing-invoice-translations-container table.existing-invoice-translations-table th {
+  padding: 0.375rem 0.75rem !important;
+  font-weight: 500 !important;
+  font-size: 0.75rem !important;
+  line-height: 1.125rem;
+  letter-spacing: 0;
+  color: #717680;
+  text-transform: capitalize;
+  background-color: #FAFAFA !important;
+}
+
+.existing-invoice-translations-container table.existing-invoice-translations-table td {
+  font-weight: 500 !important;
+  font-size: 0.875rem !important;
+  line-height: 1.125rem !important;
+  text-align: start;
+  padding: 0.3125rem 0.75rem !important;
+  color: #535862 !important;
+}
+
 /* app/views/kaui/admin_tenants/_show_catalog_simple.erb */
 
 #catalog_simple, #catalog_xml {

--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -53,6 +53,12 @@ module Kaui
         @invoice_template = nil
       end
 
+      fetch_invoice_translations = promise do
+        Kaui::AdminTenant.get_invoice_translations(options)
+      rescue StandardError
+        @invoice_translations = {}
+      end
+
       fetch_tenant_plugin_config = promise { Kaui::AdminTenant.get_tenant_plugin_config(options) }
 
       @catalog_versions = []
@@ -74,6 +80,12 @@ module Kaui
         wait(fetch_invoice_template)
       rescue StandardError
         nil
+      end
+
+      @invoice_translations = begin
+        wait(fetch_invoice_translations)
+      rescue StandardError
+        {}
       end
 
       @tenant_plugin_config = begin

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -23,6 +23,16 @@ module Kaui
         KillBillClient::Model::Invoice.upload_invoice_translation(invoice_translation, locale, delete_if_exists, user, reason, comment, options)
       end
 
+      # Return a map of locale => invoice translation content, for every invoice translation uploaded for the tenant
+      def get_invoice_translations(options = {})
+        raw_translations = KillBillClient::Model::Tenant.search_tenant_config('INVOICE_TRANSLATION_', options)
+
+        raw_translations.each_with_object({}) do |e, hsh|
+          locale = e.key.gsub('INVOICE_TRANSLATION_', '')
+          hsh[locale] = e.values[0]
+        end
+      end
+
       def upload_catalog_translation(catalog_translation, locale, delete_if_exists, user = nil, reason = nil, comment = nil, options = {})
         KillBillClient::Model::Invoice.upload_catalog_translation(catalog_translation, locale, delete_if_exists, user, reason, comment, options)
       end

--- a/app/views/kaui/admin_tenants/_form_invoice_translation.erb
+++ b/app/views/kaui/admin_tenants/_form_invoice_translation.erb
@@ -1,5 +1,54 @@
 <% if can? :config_upload, Kaui::AdminTenant %>
   <div class="tab-pane fade" id="InvoiceTranslation">
+    <div class="existing-invoice-translations-container mb-4">
+      <div class="d-flex flex-column">
+        <div class="existing-invoice-translations-header mb-3">
+          <div class="d-flex align-items-start flex-column">
+            <h2>Existing Invoice Translations</h2>
+          </div>
+        </div>
+        <div>
+          <table id="existing-invoice-translations-for-tenants" class="existing-invoice-translations-table">
+            <span class='label'>
+            </span>
+            <% if @invoice_translations.blank? %>
+              No invoice translation defined for tenant
+            <% else %>
+              <thead>
+                <tr>
+                  <th>Locale</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @invoice_translations.each do |locale, content| %>
+                  <tr>
+                    <td><%= locale %></td>
+                    <td class="text-end">
+                      <%= render "kaui/components/button/button", {
+                        label: 'View Source',
+                        variant: "outline-secondary d-inline-flex align-items-center gap-1",
+                        type: "button",
+                        html_class: "kaui-button custom-hover",
+                        html_options: {
+                          onclick: '$(this).blur(); $(this).closest("tr").next(".invoice-translation-source-row").toggle(); return false;'
+                        }
+                      } %>
+                    </td>
+                  </tr>
+                  <tr class="invoice-translation-source-row" style="display: none;">
+                    <td colspan="2">
+                      <pre class="mb-0 p-2 bg-light" style="max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; font-family: monospace; font-size: 12px;"><%= html_escape(content) %></pre>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            <% end %>
+          </table>
+        </div>
+      </div>
+    </div>
+
     <%= form_tag({:action => :upload_invoice_translation}, :method => 'post', :multipart => true, :class => 'form-horizontal') do %>
         <%= hidden_field_tag(:id, @tenant.id) %>
 


### PR DESCRIPTION
## Summary

Previously, uploading an invoice translation only showed a success flash message — there was no way to see what translations had already been uploaded for a tenant.

This adds a table listing existing invoice translations to the "Invoice Translation" tab on the Admin Tenant show page, similar to the "Existing Overdue Config" / "Existing Plans" tables on the other tabs.

## Changes

- `Kaui::AdminTenant.get_invoice_translations`: lists all uploaded invoice translations for a tenant via `KillBillClient::Model::Tenant.search_tenant_config('INVOICE_TRANSLATION_', ...)`. Kill Bill has no dedicated "list translations" endpoint, but translations are stored as per-tenant config entries keyed by `INVOICE_TRANSLATION_<locale>`, so the same prefix-search technique already used for `get_tenant_plugin_config` (`PLUGIN_CONFIG_` prefix) applies here.
- `AdminTenantsController#show`: fetches the translations map alongside the other tab data (catalog versions, overdue config, invoice template, etc.) using the existing promise/wait pattern.
- `_form_invoice_translation.erb`: renders a table (styled consistently with the Overdue/Catalog tabs) listing each uploaded locale with a "View Source" toggle to inspect the translation properties content, above the existing upload form.
- `tenants.css`: styles for the new table, matching the existing `existing-*-table` conventions.

## Notes

- There is no delete endpoint for individual invoice translations in Kill Bill (only overwrite via re-upload with `deleteIfExists`), so no delete action was added.