### PR TITLE
feat: add API endpoint to create a tenant programmatically (#627)

### DIFF
--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -614,6 +614,52 @@ module Kaui
       redirect_to admin_tenant_path(tenant.id), notice: "Tenant was switched to #{tenant.name}"
     end
 
+    # API endpoint to create a tenant programmatically (used by Aviate)
+    def create_tenant
+      # Validate required parameters
+      required_params = %i[name tenant_key tenant_secret kb_tenant_id]
+      missing = required_params.select { |p| params[p].blank? }
+      if missing.any?
+        render json: { error: "Missing required parameters: #{missing.join(', ')}" }, status: :bad_request
+        return
+      end
+
+      # Check for duplicate tenant (by name or kb_tenant_id)
+      if Kaui::Tenant.exists?(name: params[:name])
+        render json: { error: "Tenant with name '#{params[:name]}' already exists" }, status: :conflict
+        return
+      end
+      if Kaui::Tenant.exists?(kb_tenant_id: params[:kb_tenant_id])
+        render json: { error: "Tenant with kb_tenant_id '#{params[:kb_tenant_id]}' already exists" }, status: :conflict
+        return
+      end
+
+      begin
+        tenant = Kaui::Tenant.new(
+          name: params[:name],
+          api_key: params[:tenant_key],
+          api_secret: params[:tenant_secret],
+          kb_tenant_id: params[:kb_tenant_id]
+        )
+        tenant.save!
+
+        # Grant access to the new tenant for the current user
+        tenant.kaui_allowed_users << Kaui::AllowedUser.where(kb_username: current_user.kb_username).first_or_create
+
+        render json: {
+          id: tenant.id,
+          name: tenant.name,
+          kb_tenant_id: tenant.kb_tenant_id,
+          api_key: tenant.api_key,
+          created_at: tenant.created_at
+        }, status: :created
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { error: "Validation failed: #{e.message}" }, status: :unprocessable_entity
+      rescue StandardError => e
+        render json: { error: "Failed to create tenant: #{e.message}" }, status: :internal_server_error
+      end
+    end
+
     private
 
     # Share code to handle render on error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Kaui::Engine.routes.draw do
     post '/upload_invoice_translation' => 'admin_tenants#upload_invoice_translation', :as => 'admin_tenant_upload_invoice_translation'
     post '/upload_catalog_translation' => 'admin_tenants#upload_catalog_translation', :as => 'admin_tenant_upload_catalog_translation'
     post '/upload_plugin_config' => 'admin_tenants#upload_plugin_config', :as => 'admin_tenant_upload_plugin_config'
+    post '/create_tenant' => 'admin_tenants#create_tenant', :as => 'admin_tenant_create_tenant'
     delete '/remove_allowed_user' => 'admin_tenants#remove_allowed_user', :as => 'remove_allowed_user'
     put '/add_allowed_user' => 'admin_tenants#add_allowed_user', :as => 'add_allowed_user'
     get '/allowed_users' => 'admin_tenants#allowed_users', :as => 'admin_tenant_allowed_users'

--- a/test/integration/kaui/tenant_api_test.rb
+++ b/test/integration/kaui/tenant_api_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Kaui
+  class TenantApiTest < IntegrationTestHelper
+    setup do
+      sign_in_as_admin
+    end
+
+    test 'POST create_tenant creates a new tenant successfully' do
+      tenant_params = {
+        name: 'API Created Tenant',
+        tenant_key: 'api_tenant_key_001',
+        tenant_secret: 'api_tenant_secret_001',
+        kb_tenant_id: 'api-kb-tenant-id-001'
+      }
+
+      assert_difference -> { Kaui::Tenant.count } => 1,
+                        -> { Kaui::AllowedUserTenant.count } => 1 do
+        post '/kaui/admin_tenants/create_tenant', params: tenant_params, as: :json
+      end
+
+      assert_response :created
+      json = JSON.parse(response.body)
+      assert_equal 'API Created Tenant', json['name']
+      assert_equal 'api-kb-tenant-id-001', json['kb_tenant_id']
+      assert_equal 'api_tenant_key_001', json['api_key']
+      assert_not_nil json['id']
+      assert_not_nil json['created_at']
+    end
+
+    test 'POST create_tenant returns 400 when required params are missing' do
+      post '/kaui/admin_tenants/create_tenant', params: { name: 'Test' }, as: :json
+
+      assert_response :bad_request
+      json = JSON.parse(response.body)
+      assert_includes json['error'], 'Missing required parameters'
+    end
+
+    test 'POST create_tenant returns 409 when tenant name already exists' do
+      # Create a tenant first
+      post '/kaui/admin_tenants/create_tenant',
+           params: { name: 'Duplicate Test', tenant_key: 'dup_key_1', tenant_secret: 'dup_secret_1', kb_tenant_id: 'dup-kb-id-1' },
+           as: :json
+      assert_response :created
+
+      # Try to create another with the same name
+      post '/kaui/admin_tenants/create_tenant',
+           params: { name: 'Duplicate Test', tenant_key: 'dup_key_2', tenant_secret: 'dup_secret_2', kb_tenant_id: 'dup-kb-id-2' },
+           as: :json
+
+      assert_response :conflict
+      json = JSON.parse(response.body)
+      assert_includes json['error'], 'already exists'
+    end
+
+    test 'POST create_tenant returns 409 when kb_tenant_id already exists' do
+      # Create a tenant first
+      post '/kaui/admin_tenants/create_tenant',
+           params: { name: 'First Tenant', tenant_key: 'key_a', tenant_secret: 'secret_a', kb_tenant_id: 'shared-kb-id' },
+           as: :json
+      assert_response :created
+
+      # Try to create another with the same kb_tenant_id
+      post '/kaui/admin_tenants/create_tenant',
+           params: { name: 'Second Tenant', tenant_key: 'key_b', tenant_secret: 'secret_b', kb_tenant_id: 'shared-kb-id' },
+           as: :json
+
+      assert_response :conflict
+      json = JSON.parse(response.body)
+      assert_includes json['error'], 'already exists'
+    end
+
+    test 'POST create_tenant requires authentication' do
+      # Sign out first
+      sign_out :user
+
+      post '/kaui/admin_tenants/create_tenant',
+           params: { name: 'No Auth', tenant_key: 'no_auth', tenant_secret: 'no_auth', kb_tenant_id: 'no-auth-id' },
+           as: :json
+
+      assert_response :redirect
+      assert_redirected_to SIGN_IN_PATH
+    end
+
+    private
+
+    def sign_in_as_admin
+      post SIGN_IN_PATH, params: { user: { kb_username: USERNAME, password: PASSWORD } }
+      assert_redirected_to TENANTS_PATH
+      follow_redirect!
+
+      # Select the first tenant
+      tenant = Kaui::Tenant.first
+      post select_tenant_path, params: { tenant_id: tenant.id } if tenant
+    rescue StandardError
+      # May already be signed in from setup
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #627 — Add a Kaui API endpoint to create a tenant.

Adds `POST /kaui/admin_tenants/create_tenant` endpoint for Aviate to provision tenants programmatically.

## Request

```json
POST /kaui/admin_tenants/create_tenant
Content-Type: application/json

{
  "name": "My Tenant",
  "tenant_key": "api_key_123",
  "tenant_secret": "secret_456",
  "kb_tenant_id": "kb-tenant-uuid"
}
```

## Response (201 Created)

```json
{
  "id": 1,
  "name": "My Tenant",
  "kb_tenant_id": "kb-tenant-uuid",
  "api_key": "api_key_123",
  "created_at": "2026-07-25T..."
}
```

## Error Responses

- `400` — Missing required parameters
- `409` — Duplicate tenant (name or kb_tenant_id)
- `422` — Validation failed

## Implementation

- Endpoint is authenticated (uses `before_action :authenticate_user!`)
- Creates record in `kaui_tenants` table
- Creates corresponding record in `kaui_allowed_user_tenants` via association
- Returns tenant details as JSON