### PR TITLE
fix: remove broken invoice translations listing table (#624)

### DIFF
--- a/app/controllers/kaui/admin_tenants_controller.rb
+++ b/app/controllers/kaui/admin_tenants_controller.rb
@@ -53,12 +53,6 @@ module Kaui
         @invoice_template = nil
       end
 
-      fetch_invoice_translations = promise do
-        Kaui::AdminTenant.get_invoice_translations(options)
-      rescue StandardError
-        @invoice_translations = {}
-      end
-
       fetch_tenant_plugin_config = promise { Kaui::AdminTenant.get_tenant_plugin_config(options) }
 
       @catalog_versions = []
@@ -80,12 +74,6 @@ module Kaui
         wait(fetch_invoice_template)
       rescue StandardError
         nil
-      end
-
-      @invoice_translations = begin
-        wait(fetch_invoice_translations)
-      rescue StandardError
-        {}
       end
 
       @tenant_plugin_config = begin

--- a/app/models/kaui/admin_tenant.rb
+++ b/app/models/kaui/admin_tenant.rb
@@ -23,16 +23,6 @@ module Kaui
         KillBillClient::Model::Invoice.upload_invoice_translation(invoice_translation, locale, delete_if_exists, user, reason, comment, options)
       end
 
-      # Return a map of locale => invoice translation content, for every invoice translation uploaded for the tenant
-      def get_invoice_translations(options = {})
-        raw_translations = KillBillClient::Model::Tenant.search_tenant_config('INVOICE_TRANSLATION_', options)
-
-        raw_translations.each_with_object({}) do |e, hsh|
-          locale = e.key.gsub('INVOICE_TRANSLATION_', '')
-          hsh[locale] = e.values[0]
-        end
-      end
-
       def upload_catalog_translation(catalog_translation, locale, delete_if_exists, user = nil, reason = nil, comment = nil, options = {})
         KillBillClient::Model::Invoice.upload_catalog_translation(catalog_translation, locale, delete_if_exists, user, reason, comment, options)
       end

--- a/app/views/kaui/admin_tenants/_form_invoice_translation.erb
+++ b/app/views/kaui/admin_tenants/_form_invoice_translation.erb
@@ -1,54 +1,5 @@
 <% if can? :config_upload, Kaui::AdminTenant %>
   <div class="tab-pane fade" id="InvoiceTranslation">
-    <div class="existing-invoice-translations-container mb-4">
-      <div class="d-flex flex-column">
-        <div class="existing-invoice-translations-header mb-3">
-          <div class="d-flex align-items-start flex-column">
-            <h2>Existing Invoice Translations</h2>
-          </div>
-        </div>
-        <div>
-          <table id="existing-invoice-translations-for-tenants" class="existing-invoice-translations-table">
-            <span class='label'>
-            </span>
-            <% if @invoice_translations.blank? %>
-              No invoice translation defined for tenant
-            <% else %>
-              <thead>
-                <tr>
-                  <th>Locale</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                <% @invoice_translations.each do |locale, content| %>
-                  <tr>
-                    <td><%= locale %></td>
-                    <td class="text-end">
-                      <%= render "kaui/components/button/button", {
-                        label: 'View Source',
-                        variant: "outline-secondary d-inline-flex align-items-center gap-1",
-                        type: "button",
-                        html_class: "kaui-button custom-hover",
-                        html_options: {
-                          onclick: '$(this).blur(); $(this).closest("tr").next(".invoice-translation-source-row").toggle(); return false;'
-                        }
-                      } %>
-                    </td>
-                  </tr>
-                  <tr class="invoice-translation-source-row" style="display: none;">
-                    <td colspan="2">
-                      <pre class="mb-0 p-2 bg-light" style="max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; font-family: monospace; font-size: 12px;"><%= html_escape(content) %></pre>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            <% end %>
-          </table>
-        </div>
-      </div>
-    </div>
-
     <%= form_tag({:action => :upload_invoice_translation}, :method => 'post', :multipart => true, :class => 'form-horizontal') do %>
         <%= hidden_field_tag(:id, @tenant.id) %>
 


### PR DESCRIPTION
## Root Cause

The `get_invoice_translations` method in commit 8821cfaa uses `search_tenant_config('INVOICE_TRANSLATION_')` which queries the **tenant config** endpoint:

```
GET /1.0/kb/tenants/uploadPerTenantConfig/INVOICE_TRANSLATION_/search
```

But invoice translations are stored at the **invoices** endpoint:

```
POST /1.0/kb/invoices/translation/{locale}
GET  /1.0/kb/invoices/translation/{locale}
```

These are completely different KB storage mechanisms — the search always returns empty because it looks in the wrong place. KB has no API to list all invoice translations.

## Fix

Removed the broken listing feature while keeping the upload functionality intact:
- `app/models/kaui/admin_tenant.rb` — removed `get_invoice_translations` method
- `app/controllers/kaui/admin_tenants_controller.rb` — removed fetch of translations in show action
- `app/views/kaui/admin_tenants/_form_invoice_translation.erb` — removed empty table UI

Fixes #624