### PR TITLE
fix: make invoice number clickable on invoices listing (#629)

### DIFF
--- a/lib/kaui.rb
+++ b/lib/kaui.rb
@@ -135,6 +135,8 @@ module Kaui
         view_context.humanized_money_with_symbol(invoice.balance_to_money)
       when 'invoice_id'
         view_context.link_to(invoice.invoice_id, view_context.url_for(controller: :invoices, action: :show, account_id: invoice.account_id, id: invoice.invoice_id))
+      when 'invoice_number'
+        view_context.link_to(invoice.invoice_number, view_context.url_for(controller: :invoices, action: :show, account_id: invoice.account_id, id: invoice.invoice_id))
       when 'status'
         default_label = 'label-info'
         default_label = 'label-default' if invoice&.status == 'DRAFT'


### PR DESCRIPTION
Makes the invoice number column a hyperlink on the invoices listing page, matching the existing payment number clickable behavior on the payments page.\n\nBefore: invoice number was plain text\nAfter: invoice number links to `/accounts/{account_id}/invoices/{invoice_id}`\n\nFixes #629