### PR TITLE
fix: prevent right-side overflow on pages with account sidebar (#631)

### DIFF
--- a/app/assets/stylesheets/kaui/common.css
+++ b/app/assets/stylesheets/kaui/common.css
@@ -1060,6 +1060,13 @@ form[id^="new_tag_definition"] #object_types div .tag-definition-select {
   margin: 0 auto;
   padding-bottom: 0.625rem !important;
   max-width: 80rem;
+  overflow-x: hidden;
+}
+
+/* Prevent flex children from overflowing the sidebar + content layout */
+.kaui-container > .d-flex > :not(.account-sidebar-area) {
+  min-width: 0;
+  flex: 1;
 }
 
 header {


### PR DESCRIPTION
Adds `overflow-x: hidden` to `.kaui-container` and ensures flex children properly shrink within the sidebar + content layout.\n\n**Root cause:** Pages with account sidebar use `d-flex` with `gap: 4rem`. The content child often has `w-100` which doesn't account for the sidebar width, causing overflow on the right side showing the body's grey background.\n\n**Fix:**\n- `overflow-x: hidden` clips any overflow\n- `min-width: 0; flex: 1` on content children allows proper flex shrinking\n\nFixes #631