### PR TITLE
fix: narrow CSS overflow fix — remove overly broad flex: 1 (#631)

### DIFF
--- a/app/assets/stylesheets/kaui/common.css
+++ b/app/assets/stylesheets/kaui/common.css
@@ -1066,7 +1066,6 @@ form[id^="new_tag_definition"] #object_types div .tag-definition-select {
 /* Prevent flex children from overflowing the sidebar + content layout */
 .kaui-container > .d-flex > :not(.account-sidebar-area) {
   min-width: 0;
-  flex: 1;
 }
 
 header {


### PR DESCRIPTION
Refinement of #639 — removes the overly broad `flex: 1` rule that could affect flex children on pages without the sidebar layout. Keeps only `min-width: 0` which safely allows flex children to shrink.\n\nThe `overflow-x: hidden` on `.kaui-container` was the primary fix; this just tightens the selector.\n\nRef: #631